### PR TITLE
feat: AI Vibe copilot for natural language level design

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -42,13 +42,15 @@
     "three": "^0.181.1",
     "tw-animate-css": "^1.4.0",
     "valtio": "^2.2.0",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
+    "ws": "^8.19.0"
   },
   "devDependencies": {
     "@types/node": "^24.10.1",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",
     "@types/three": "^0.181.0",
+    "@types/ws": "^8.18.1",
     "@vitejs/plugin-react-swc": "^4.1.0",
     "typescript": "^5.9.3",
     "vite": "^7.1.12",

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -14,6 +14,7 @@
     "@base-ui/react": "^1.2.0",
     "@fal-ai/client": "^1.5.6",
     "@fontsource-variable/geist": "^5.2.8",
+    "@google/genai": "^1.45.0",
     "@react-three/drei": "^10.7.6",
     "@react-three/fiber": "^9.4.0",
     "@react-three/rapier": "^2.2.0",

--- a/apps/editor/server/codex-bridge-plugin.ts
+++ b/apps/editor/server/codex-bridge-plugin.ts
@@ -1,0 +1,399 @@
+import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { createInterface, type Interface as ReadlineInterface } from "node:readline";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Plugin, PreviewServer, ViteDevServer } from "vite";
+import { WebSocketServer, type WebSocket } from "ws";
+
+type CodexSession = {
+  process: ChildProcess;
+  readline: ReadlineInterface;
+  ws: WebSocket;
+  requestId: number;
+  pendingRequests: Map<number, { resolve: (value: unknown) => void; reject: (error: Error) => void }>;
+  pendingToolCalls: Map<number, { resolve: (value: unknown) => void }>;
+  threadId?: string;
+  agentText: string;
+};
+
+export function createCodexBridgePlugin(): Plugin {
+  return {
+    name: "codex-bridge",
+    configureServer(server) {
+      registerCodexStatusApi(server);
+      registerCodexWebSocket(server as ViteDevServer);
+    },
+    configurePreviewServer(server) {
+      registerCodexStatusApi(server);
+    }
+  };
+}
+
+// ── HTTP status endpoint ──────────────────────────────────────
+
+function registerCodexStatusApi(server: Pick<ViteDevServer, "middlewares"> | Pick<PreviewServer, "middlewares">) {
+  server.middlewares.use(async (req: IncomingMessage, res: ServerResponse, next: () => void) => {
+    if (req.url?.split("?")[0] !== "/api/codex/status") {
+      next();
+      return;
+    }
+
+    const result = checkCodexAvailability();
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(result));
+  });
+}
+
+function checkCodexAvailability(): { available: boolean; version?: string; error?: string } {
+  // Ensure common binary paths are included (Homebrew, nvm, etc.)
+  const extraPaths = ["/opt/homebrew/bin", "/usr/local/bin", `${process.env.HOME}/.local/bin`];
+  const envPath = `${process.env.PATH}:${extraPaths.join(":")}`;
+
+  try {
+    const version = execSync("codex --version", {
+      encoding: "utf-8",
+      timeout: 5000,
+      env: { ...process.env, PATH: envPath },
+      stdio: ["pipe", "pipe", "pipe"]
+    }).trim();
+    return { available: true, version };
+  } catch {
+    return { available: false, error: "Codex CLI not found. Install with: npm install -g @openai/codex" };
+  }
+}
+
+// ── WebSocket bridge ──────────────────────────────────────────
+
+function registerCodexWebSocket(server: ViteDevServer) {
+  if (!server.httpServer) return;
+
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.httpServer.on("upgrade", (request, socket, head) => {
+    if (request.url === "/ws/codex") {
+      wss.handleUpgrade(request, socket, head, (ws) => {
+        wss.emit("connection", ws, request);
+      });
+    }
+  });
+
+  wss.on("connection", (ws) => {
+    let session: CodexSession | null = null;
+
+    ws.on("message", (data) => {
+      try {
+        const msg = JSON.parse(data.toString());
+        handleClientMessage(ws, msg, session, (s) => { session = s; });
+      } catch (error) {
+        sendToClient(ws, { type: "error", message: "Invalid message format", fatal: false });
+      }
+    });
+
+    ws.on("close", () => {
+      if (session) {
+        cleanupSession(session);
+        session = null;
+      }
+    });
+  });
+}
+
+async function handleClientMessage(
+  ws: WebSocket,
+  msg: { type: string; [key: string]: unknown },
+  session: CodexSession | null,
+  setSession: (s: CodexSession | null) => void
+) {
+  switch (msg.type) {
+    case "start": {
+      if (session) {
+        cleanupSession(session);
+      }
+
+      try {
+        const newSession = await startCodexSession(ws, msg as {
+          type: "start";
+          model: string;
+          systemPrompt: string;
+          tools: Array<{ name: string; description: string; inputSchema: Record<string, unknown> }>;
+          userMessage: string;
+        });
+        setSession(newSession);
+      } catch (error) {
+        sendToClient(ws, {
+          type: "error",
+          message: error instanceof Error ? error.message : "Failed to start Codex session",
+          fatal: true
+        });
+      }
+      break;
+    }
+
+    case "tool_result": {
+      if (!session) return;
+      const { id, result, success } = msg as { type: "tool_result"; id: string; result: string; success: boolean };
+      const rpcId = parseInt(id, 10);
+      const pending = session.pendingToolCalls.get(rpcId);
+
+      if (pending) {
+        session.pendingToolCalls.delete(rpcId);
+        // Send JSON-RPC response back to codex
+        const parsed = tryParseJson(result);
+        sendToCodex(session, {
+          id: rpcId,
+          result: {
+            contentItems: [{ type: "inputText", text: typeof parsed === "string" ? parsed : JSON.stringify(parsed) }],
+            success
+          }
+        });
+        pending.resolve(null);
+      }
+      break;
+    }
+
+    case "abort": {
+      if (session) {
+        cleanupSession(session);
+        setSession(null);
+      }
+      break;
+    }
+  }
+}
+
+async function startCodexSession(
+  ws: WebSocket,
+  config: {
+    model: string;
+    systemPrompt: string;
+    tools: Array<{ name: string; description: string; inputSchema: Record<string, unknown> }>;
+    userMessage: string;
+  }
+): Promise<CodexSession> {
+  sendToClient(ws, { type: "status", status: "connecting" });
+
+  // Spawn codex app-server — extend PATH to find Homebrew/nvm binaries
+  const extraPaths = ["/opt/homebrew/bin", "/usr/local/bin", `${process.env.HOME}/.local/bin`];
+  const envPath = `${process.env.PATH}:${extraPaths.join(":")}`;
+
+  const proc = spawn("codex", ["app-server"], {
+    stdio: ["pipe", "pipe", "inherit"],
+    env: { ...process.env, PATH: envPath }
+  });
+
+  const readline = createInterface({ input: proc.stdout! });
+
+  const session: CodexSession = {
+    process: proc,
+    readline,
+    ws,
+    requestId: 0,
+    pendingRequests: new Map(),
+    pendingToolCalls: new Map(),
+    agentText: ""
+  };
+
+  // Set up stdio message handling
+  readline.on("line", (line) => {
+    try {
+      const msg = JSON.parse(line);
+      handleCodexMessage(session, msg);
+    } catch {
+      // Ignore non-JSON lines (e.g. log output)
+    }
+  });
+
+  proc.on("exit", (code) => {
+    if (ws.readyState === ws.OPEN) {
+      sendToClient(ws, {
+        type: "error",
+        message: `Codex process exited with code ${code}`,
+        fatal: true
+      });
+    }
+  });
+
+  // 1. Handshake
+  await sendCodexRequest(session, "initialize", {
+    clientInfo: { name: "trident-editor", title: "Trident Editor", version: "0.1.0" },
+    capabilities: { experimentalApi: true }
+  });
+  sendToCodex(session, { method: "initialized", params: {} });
+
+  // 2. Start thread with dynamic tools
+  const dynamicTools = config.tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema
+  }));
+
+  const threadResult = await sendCodexRequest(session, "thread/start", {
+    model: config.model,
+    baseInstructions: config.systemPrompt,
+    dynamicTools
+  }) as { thread?: { id?: string } };
+
+  session.threadId = threadResult?.thread?.id;
+
+  sendToClient(ws, { type: "status", status: "thinking" });
+
+  // 3. Start turn with user message
+  sendToCodex(session, {
+    method: "turn/start",
+    id: ++session.requestId,
+    params: {
+      threadId: session.threadId,
+      input: [{ type: "text", text: config.userMessage }]
+    }
+  });
+
+  return session;
+}
+
+function handleCodexMessage(session: CodexSession, msg: { id?: number; method?: string; params?: Record<string, unknown>; result?: unknown; error?: unknown }) {
+  // Handle responses to our requests
+  if (msg.id !== undefined && !msg.method) {
+    const pending = session.pendingRequests.get(msg.id);
+    if (pending) {
+      session.pendingRequests.delete(msg.id);
+      if (msg.error) {
+        pending.reject(new Error(JSON.stringify(msg.error)));
+      } else {
+        pending.resolve(msg.result);
+      }
+    }
+    return;
+  }
+
+  // Handle server-to-client requests (need response)
+  if (msg.id !== undefined && msg.method === "item/tool/call") {
+    const params = msg.params as { callId: string; tool: string; arguments: Record<string, unknown> };
+    sendToClient(session.ws, {
+      type: "tool_call",
+      id: String(msg.id),
+      name: params.tool,
+      args: params.arguments ?? {}
+    });
+    sendToClient(session.ws, { type: "status", status: "executing" });
+
+    // Store pending tool call — will be resolved when browser sends tool_result
+    session.pendingToolCalls.set(msg.id, { resolve: () => {} });
+    return;
+  }
+
+  // Handle approval requests — auto-approve for now
+  if (msg.id !== undefined && (msg.method === "item/commandExecution/requestApproval" || msg.method === "item/fileChange/requestApproval")) {
+    sendToCodex(session, { id: msg.id, result: { decision: "accept" } });
+    return;
+  }
+
+  // Handle notifications
+  if (!msg.method) return;
+
+  const params = msg.params as Record<string, unknown> | undefined;
+
+  switch (msg.method) {
+    case "item/agentMessage/delta": {
+      const delta = (params as { delta?: string })?.delta;
+      if (delta) {
+        session.agentText += delta;
+        sendToClient(session.ws, { type: "delta", text: delta });
+      }
+      break;
+    }
+
+    case "item/started": {
+      const item = params?.item as { type?: string; tool?: string; id?: string } | undefined;
+      if (item?.type === "dynamicToolCall") {
+        sendToClient(session.ws, { type: "status", status: "executing" });
+      }
+      break;
+    }
+
+    case "item/completed": {
+      const item = params?.item as { type?: string; tool?: string; id?: string; status?: string } | undefined;
+      if (item?.type === "dynamicToolCall" && item.tool) {
+        sendToClient(session.ws, {
+          type: "tool_status",
+          id: item.id ?? "",
+          name: item.tool,
+          status: item.status === "completed" ? "completed" : "failed"
+        });
+        sendToClient(session.ws, { type: "status", status: "thinking" });
+      }
+      break;
+    }
+
+    case "turn/completed": {
+      sendToClient(session.ws, {
+        type: "turn_complete",
+        text: session.agentText
+      });
+      cleanupSession(session);
+      break;
+    }
+
+    case "turn/failed": {
+      const turn = params?.turn as { error?: { message?: string } } | undefined;
+      sendToClient(session.ws, {
+        type: "error",
+        message: turn?.error?.message ?? "Turn failed",
+        fatal: true
+      });
+      cleanupSession(session);
+      break;
+    }
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function sendToCodex(session: CodexSession, msg: Record<string, unknown>) {
+  if (session.process.stdin?.writable) {
+    session.process.stdin.write(JSON.stringify(msg) + "\n");
+  }
+}
+
+function sendCodexRequest(session: CodexSession, method: string, params: Record<string, unknown>): Promise<unknown> {
+  const id = ++session.requestId;
+  return new Promise((resolve, reject) => {
+    session.pendingRequests.set(id, { resolve, reject });
+    sendToCodex(session, { method, id, params });
+
+    // Timeout after 30 seconds
+    setTimeout(() => {
+      if (session.pendingRequests.has(id)) {
+        session.pendingRequests.delete(id);
+        reject(new Error(`Codex request ${method} timed out`));
+      }
+    }, 30000);
+  });
+}
+
+function sendToClient(ws: WebSocket, msg: Record<string, unknown>) {
+  if (ws.readyState === ws.OPEN) {
+    ws.send(JSON.stringify(msg));
+  }
+}
+
+function cleanupSession(session: CodexSession) {
+  session.readline.close();
+  if (!session.process.killed) {
+    session.process.kill("SIGTERM");
+    setTimeout(() => {
+      if (!session.process.killed) {
+        session.process.kill("SIGKILL");
+      }
+    }, 5000);
+  }
+  session.pendingRequests.forEach(({ reject }) => reject(new Error("Session closed")));
+  session.pendingRequests.clear();
+  session.pendingToolCalls.clear();
+}
+
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -89,6 +89,7 @@ import { uiStore, type RightPanelId } from "@/state/ui-store";
 import type { Transform } from "@web-hammer/shared";
 import type { MeshEditMode } from "@/viewport/editing";
 import { useAppHotkeys } from "@/app/hooks/useAppHotkeys";
+import { useCopilot } from "@/app/hooks/useCopilot";
 import { useEditorSubscriptions } from "@/app/hooks/useEditorSubscriptions";
 import { useExportWorker } from "@/app/hooks/useExportWorker";
 import { clampSnapSize, resolveViewportSnapSize } from "@/viewport/utils/snap";
@@ -229,7 +230,7 @@ export function App() {
     );
   }, [activeToolId, editor, sceneRevision, selectionRevision]);
 
-  const handleSetRightPanel = (panel: RightPanelId) => {
+  const handleSetRightPanel = (panel: RightPanelId | null) => {
     uiStore.rightPanel = panel;
   };
 
@@ -1346,6 +1347,12 @@ export function App() {
     editor.redo();
   };
 
+  const copilot = useCopilot(editor);
+
+  const handleToggleCopilot = () => {
+    uiStore.copilotPanelOpen = !uiStore.copilotPanelOpen;
+  };
+
   useAppHotkeys({
     activeToolId,
     editor,
@@ -1355,6 +1362,7 @@ export function App() {
     handleGroupSelection,
     handleInvertSelectionNormals,
     handleRedo,
+    handleToggleCopilot,
     handleTranslateSelection,
     handleUndo,
     setActiveToolId: handleSetToolId,
@@ -1369,6 +1377,9 @@ export function App() {
         activeRightPanel={ui.rightPanel}
         activeToolId={toolSession.toolId}
         activeBrushShape={activeBrushShape}
+        copilot={copilot}
+        copilotPanelOpen={ui.copilotPanelOpen}
+        onToggleCopilot={handleToggleCopilot}
         aiModelPlacementActive={Boolean(aiModelDraft)}
         aiModelPlacementArmed={aiModelPlacementArmed}
         aiModelPrompt={aiModelDraft?.prompt ?? ""}

--- a/apps/editor/src/app/hooks/useAppHotkeys.ts
+++ b/apps/editor/src/app/hooks/useAppHotkeys.ts
@@ -12,6 +12,7 @@ type UseAppHotkeysOptions = {
   handleGroupSelection: () => void;
   handleInvertSelectionNormals: () => void;
   handleRedo: () => void;
+  handleToggleCopilot: () => void;
   handleTranslateSelection: (axis: TransformAxis, direction: -1 | 1) => void;
   handleUndo: () => void;
   setActiveToolId: (toolId: ToolId) => void;
@@ -28,6 +29,7 @@ export function useAppHotkeys({
   handleGroupSelection,
   handleInvertSelectionNormals,
   handleRedo,
+  handleToggleCopilot,
   handleTranslateSelection,
   handleUndo,
   setActiveToolId,
@@ -62,6 +64,12 @@ export function useAppHotkeys({
         } else {
           handleUndo();
         }
+        return;
+      }
+
+      if (modifier && event.key.toLowerCase() === "l") {
+        event.preventDefault();
+        handleToggleCopilot();
         return;
       }
 
@@ -210,6 +218,7 @@ export function useAppHotkeys({
     handleGroupSelection,
     handleInvertSelectionNormals,
     handleRedo,
+    handleToggleCopilot,
     handleTranslateSelection,
     handleUndo,
     setActiveToolId,

--- a/apps/editor/src/app/hooks/useCopilot.ts
+++ b/apps/editor/src/app/hooks/useCopilot.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { EditorCore } from "@web-hammer/editor-core";
+import type { CopilotSession } from "@/lib/copilot/types";
+import { runAgenticLoop } from "@/lib/copilot/agentic-loop";
+import { createCopilotProvider } from "@/lib/copilot/provider";
+import { buildSystemPrompt } from "@/lib/copilot/system-prompt";
+import { loadCopilotSettings, hasCopilotApiKey } from "@/lib/copilot/settings";
+import { COPILOT_TOOL_DECLARATIONS } from "@/lib/copilot/tool-declarations";
+import { executeTool } from "@/lib/copilot/tool-executor";
+
+const EMPTY_SESSION: CopilotSession = {
+  messages: [],
+  status: "idle",
+  iterationCount: 0
+};
+
+export function useCopilot(editor: EditorCore) {
+  const [session, setSession] = useState<CopilotSession>(EMPTY_SESSION);
+  const [configured, setConfigured] = useState(hasCopilotApiKey);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const check = () => setConfigured(hasCopilotApiKey());
+    window.addEventListener("focus", check);
+    window.addEventListener("storage", check);
+    return () => {
+      window.removeEventListener("focus", check);
+      window.removeEventListener("storage", check);
+    };
+  }, []);
+
+  const sendMessage = useCallback(
+    async (prompt: string) => {
+      const settings = loadCopilotSettings();
+
+      if (!settings.apiKey) {
+        setSession((prev) => ({
+          ...prev,
+          status: "error",
+          error: "No API key configured. Open Copilot settings to add one."
+        }));
+        return;
+      }
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      const provider = createCopilotProvider();
+      const systemPrompt = buildSystemPrompt(editor);
+
+      await runAgenticLoop(
+        prompt,
+        session.messages,
+        {
+          maxIterations: 25,
+          provider,
+          providerConfig: {
+            apiKey: settings.apiKey,
+            model: settings.model,
+            temperature: settings.temperature
+          },
+          systemPrompt,
+          tools: COPILOT_TOOL_DECLARATIONS,
+          executeTool: (toolCall) => executeTool(editor, toolCall),
+          onUpdate: (updated) => {
+            setSession({ ...updated, messages: [...updated.messages] });
+          }
+        },
+        controller.signal
+      );
+
+      abortRef.current = null;
+    },
+    [editor, session.messages]
+  );
+
+  const abort = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, []);
+
+  const clearHistory = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setSession(EMPTY_SESSION);
+  }, []);
+
+  return {
+    session,
+    sendMessage,
+    abort,
+    clearHistory,
+    isConfigured: configured,
+    refreshConfigured: () => setConfigured(hasCopilotApiKey())
+  };
+}

--- a/apps/editor/src/app/hooks/useCopilot.ts
+++ b/apps/editor/src/app/hooks/useCopilot.ts
@@ -4,7 +4,7 @@ import type { CopilotSession } from "@/lib/copilot/types";
 import { runAgenticLoop } from "@/lib/copilot/agentic-loop";
 import { createCopilotProvider } from "@/lib/copilot/provider";
 import { buildSystemPrompt } from "@/lib/copilot/system-prompt";
-import { loadCopilotSettings, hasCopilotApiKey } from "@/lib/copilot/settings";
+import { loadCopilotSettings, isCopilotConfigured } from "@/lib/copilot/settings";
 import { COPILOT_TOOL_DECLARATIONS } from "@/lib/copilot/tool-declarations";
 import { executeTool } from "@/lib/copilot/tool-executor";
 
@@ -16,11 +16,11 @@ const EMPTY_SESSION: CopilotSession = {
 
 export function useCopilot(editor: EditorCore) {
   const [session, setSession] = useState<CopilotSession>(EMPTY_SESSION);
-  const [configured, setConfigured] = useState(hasCopilotApiKey);
+  const [configured, setConfigured] = useState(() => isCopilotConfigured());
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
-    const check = () => setConfigured(hasCopilotApiKey());
+    const check = () => setConfigured(isCopilotConfigured());
     window.addEventListener("focus", check);
     window.addEventListener("storage", check);
     return () => {
@@ -33,11 +33,13 @@ export function useCopilot(editor: EditorCore) {
     async (prompt: string) => {
       const settings = loadCopilotSettings();
 
-      if (!settings.apiKey) {
+      if (!isCopilotConfigured(settings)) {
         setSession((prev) => ({
           ...prev,
           status: "error",
-          error: "No API key configured. Open Copilot settings to add one."
+          error: settings.provider === "codex"
+            ? 'Codex not configured. Run "codex login" in your terminal.'
+            : "No API key configured. Open Vibe settings to add one."
         }));
         return;
       }
@@ -45,29 +47,48 @@ export function useCopilot(editor: EditorCore) {
       const controller = new AbortController();
       abortRef.current = controller;
 
-      const provider = createCopilotProvider();
+      const copilotProvider = createCopilotProvider(settings.provider);
       const systemPrompt = buildSystemPrompt(editor);
 
-      await runAgenticLoop(
-        prompt,
-        session.messages,
-        {
-          maxIterations: 25,
-          provider,
-          providerConfig: {
-            apiKey: settings.apiKey,
-            model: settings.model,
-            temperature: settings.temperature
-          },
-          systemPrompt,
+      const providerConfig = {
+        apiKey: settings.provider === "gemini" ? settings.gemini.apiKey : "",
+        model: settings.provider === "gemini" ? settings.gemini.model : settings.codex.model,
+        temperature: settings.temperature
+      };
+
+      if (copilotProvider.kind === "session-based") {
+        // Codex path: provider manages its own tool-calling loop
+        await copilotProvider.provider.runSession({
+          messages: session.messages,
+          userPrompt: prompt,
           tools: COPILOT_TOOL_DECLARATIONS,
+          systemPrompt,
+          providerConfig,
           executeTool: (toolCall) => executeTool(editor, toolCall),
           onUpdate: (updated) => {
             setSession({ ...updated, messages: [...updated.messages] });
-          }
-        },
-        controller.signal
-      );
+          },
+          signal: controller.signal
+        });
+      } else {
+        // Gemini path: agentic loop
+        await runAgenticLoop(
+          prompt,
+          session.messages,
+          {
+            maxIterations: 25,
+            provider: copilotProvider.provider,
+            providerConfig,
+            systemPrompt,
+            tools: COPILOT_TOOL_DECLARATIONS,
+            executeTool: (toolCall) => executeTool(editor, toolCall),
+            onUpdate: (updated) => {
+              setSession({ ...updated, messages: [...updated.messages] });
+            }
+          },
+          controller.signal
+        );
+      }
 
       abortRef.current = null;
     },
@@ -91,6 +112,6 @@ export function useCopilot(editor: EditorCore) {
     abort,
     clearHistory,
     isConfigured: configured,
-    refreshConfigured: () => setConfigured(hasCopilotApiKey())
+    refreshConfigured: () => setConfigured(isCopilotConfigured())
   };
 }

--- a/apps/editor/src/components/EditorShell.tsx
+++ b/apps/editor/src/components/EditorShell.tsx
@@ -19,7 +19,9 @@ import type { PrimitiveNodeData, PrimitiveShape } from "@web-hammer/shared";
 import type { ToolId } from "@web-hammer/tool-system";
 import type { WorkerJob } from "@web-hammer/workers";
 import type { ReactNode } from "react";
+import type { CopilotSession } from "@/lib/copilot/types";
 import { AiModelPromptBar } from "@/components/editor-shell/AiModelPromptBar";
+import { CopilotPanel } from "@/components/editor-shell/CopilotPanel";
 import { EditorMenuBar } from "@/components/editor-shell/EditorMenuBar";
 import { InspectorSidebar } from "@/components/editor-shell/InspectorSidebar";
 import { SpatialAnalysisPanel } from "@/components/editor-shell/SpatialAnalysisPanel";
@@ -41,11 +43,20 @@ import { cn } from "@/lib/utils";
 type EditorShellProps = {
   activeBrushShape: BrushShape;
   aiModelPlacementActive: boolean;
+  copilot: {
+    session: CopilotSession;
+    sendMessage: (prompt: string) => void;
+    abort: () => void;
+    clearHistory: () => void;
+    isConfigured: boolean;
+    refreshConfigured: () => void;
+  };
+  copilotPanelOpen: boolean;
   aiModelPlacementArmed: boolean;
   aiModelPrompt: string;
   aiModelPromptBusy: boolean;
   aiModelPromptError?: string;
-  activeRightPanel: RightPanelId;
+  activeRightPanel: RightPanelId | null;
   activeToolId: ToolId;
   activeViewportId: ViewportPaneId;
   analysis: SceneSpatialAnalysis;
@@ -113,12 +124,13 @@ type EditorShellProps = {
   onSetMeshEditMode: (mode: MeshEditMode) => void;
   onSetSculptBrushRadius: (value: number) => void;
   onSetSculptBrushStrength: (value: number) => void;
-  onSetRightPanel: (panel: RightPanelId) => void;
+  onSetRightPanel: (panel: RightPanelId | null) => void;
   onSetSnapEnabled: (enabled: boolean) => void;
   onSetSnapSize: (snapSize: GridSnapValue) => void;
   onStopPhysics: () => void;
   onSetTransformMode: (mode: "rotate" | "scale" | "translate") => void;
   onSetToolId: (toolId: ToolId) => void;
+  onToggleCopilot: () => void;
   onToggleViewportQuality: () => void;
   onSetViewMode: (viewMode: ViewModeId) => void;
   onSplitBrushAtCoordinate: (nodeId: string, axis: TransformAxis, coordinate: number) => void;
@@ -158,6 +170,8 @@ export function EditorShell({
   activeBrushShape,
   aiModelPlacementActive,
   aiModelPlacementArmed,
+  copilot,
+  copilotPanelOpen,
   aiModelPrompt,
   aiModelPromptBusy,
   aiModelPromptError,
@@ -235,6 +249,7 @@ export function EditorShell({
   onStopPhysics,
   onSetTransformMode,
   onSetToolId,
+  onToggleCopilot,
   onToggleViewportQuality,
   onSetViewMode,
   onSplitBrushAtCoordinate,
@@ -356,6 +371,7 @@ export function EditorShell({
         <EditorMenuBar
           canRedo={canRedo}
           canUndo={canUndo}
+          copilotOpen={copilotPanelOpen}
           onClearSelection={onClearSelection}
           onCreateBrush={onCreateBrush}
           onDeleteSelection={onDeleteSelection}
@@ -371,16 +387,18 @@ export function EditorShell({
           onLoadWhmap={onLoadWhmap}
           onRedo={onRedo}
           onSaveWhmap={onSaveWhmap}
+          onToggleCopilot={onToggleCopilot}
           onToggleViewportQuality={onToggleViewportQuality}
           onUndo={onUndo}
           viewportQuality={viewportQuality}
         />
       </header>
 
-      <main className="relative min-h-0 flex-1">
-        <div className="absolute inset-0">
-          <ViewportLayout renderViewportPane={renderViewportPane} viewMode={viewMode} />
-        </div>
+      <main className="relative min-h-0 flex-1 flex">
+        <div className="relative min-w-0 flex-1">
+          <div className="absolute inset-0">
+            <ViewportLayout renderViewportPane={renderViewportPane} viewMode={viewMode} />
+          </div>
 
         <ToolPalette
           activeBrushShape={activeBrushShape}
@@ -502,6 +520,21 @@ export function EditorShell({
           viewModeLabel={getViewModePreset(viewMode).shortLabel}
           viewport={activeViewport}
         />
+        </div>
+
+        {copilotPanelOpen && (
+          <div className="w-80 shrink-0">
+            <CopilotPanel
+              isConfigured={copilot.isConfigured}
+              onAbort={copilot.abort}
+              onClearHistory={copilot.clearHistory}
+              onClose={onToggleCopilot}
+              onSendMessage={copilot.sendMessage}
+              onSettingsChanged={copilot.refreshConfigured}
+              session={copilot.session}
+            />
+          </div>
+        )}
       </main>
     </div>
   );

--- a/apps/editor/src/components/editor-shell/CopilotPanel.tsx
+++ b/apps/editor/src/components/editor-shell/CopilotPanel.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Bot, Loader2, Send, Square, Trash2, Wrench, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { CopilotSettingsDialog } from "@/components/editor-shell/CopilotSettingsDialog";
+import type { CopilotMessage, CopilotSession } from "@/lib/copilot/types";
+import { cn } from "@/lib/utils";
+
+type CopilotPanelProps = {
+  onClose: () => void;
+  onSendMessage: (prompt: string) => void;
+  onAbort: () => void;
+  onClearHistory: () => void;
+  onSettingsChanged: () => void;
+  session: CopilotSession;
+  isConfigured: boolean;
+};
+
+export function CopilotPanel({
+  onClose,
+  onSendMessage,
+  onAbort,
+  onClearHistory,
+  onSettingsChanged,
+  session,
+  isConfigured
+}: CopilotPanelProps) {
+  const [input, setInput] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isActive = session.status === "thinking" || session.status === "executing";
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [session.messages, session.status]);
+
+  const handleSubmit = () => {
+    const trimmed = input.trim();
+
+    if (!trimmed || isActive) {
+      return;
+    }
+
+    setInput("");
+    onSendMessage(trimmed);
+  };
+
+  const visibleMessages = session.messages.filter((m) => m.role !== "tool");
+
+  return (
+    <div className="flex h-full flex-col border-l border-white/8 bg-[#08110e]/94 backdrop-blur-xl">
+      {/* Header */}
+      <div className="flex shrink-0 items-center justify-between border-b border-white/8 px-3 py-2">
+        <div className="flex items-center gap-2 text-[11px] font-medium tracking-[0.18em] text-foreground/52 uppercase">
+          <Bot className="size-3.5 text-emerald-400" />
+          AI Vibe
+        </div>
+        <div className="flex items-center gap-0.5">
+          {session.messages.length > 0 && (
+            <Button
+              className="size-7 rounded-lg text-foreground/48 hover:text-foreground"
+              onClick={onClearHistory}
+              size="icon-sm"
+              title="Clear history"
+              variant="ghost"
+            >
+              <Trash2 className="size-3.5" />
+            </Button>
+          )}
+          <CopilotSettingsDialog onSaved={onSettingsChanged} />
+          <Button
+            className="size-7 rounded-lg text-foreground/48 hover:text-foreground"
+            onClick={onClose}
+            size="icon-sm"
+            variant="ghost"
+          >
+            <X className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto px-3 py-3" ref={scrollRef}>
+        {visibleMessages.length === 0 && !isActive ? (
+          <div className="flex h-full items-center justify-center">
+            <div className="space-y-2 text-center">
+              <Bot className="mx-auto size-8 text-foreground/20" />
+              <p className="text-xs text-foreground/40">
+                {isConfigured
+                  ? "Describe what you want to build."
+                  : "Configure your API key in settings to get started."}
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2.5">
+            {visibleMessages.map((message) => (
+              <MessageBubble key={message.id} message={message} />
+            ))}
+            {isActive && <ThinkingIndicator session={session} />}
+            {session.status === "error" && session.error && (
+              <div className="rounded-xl bg-rose-500/10 px-2.5 py-1.5 text-[11px] text-rose-300">
+                {session.error}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Input */}
+      <div className="shrink-0 border-t border-white/8 p-3">
+        <div className="flex gap-2">
+          <Input
+            autoFocus
+            className="h-9 flex-1 rounded-xl border-white/10 bg-white/[0.045] text-xs"
+            disabled={isActive || !isConfigured}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                handleSubmit();
+              }
+            }}
+            placeholder={isConfigured ? "Describe what to build..." : "Set up API key first"}
+            ref={inputRef}
+            value={input}
+          />
+          {isActive ? (
+            <Button
+              className="size-9 shrink-0 rounded-xl"
+              onClick={onAbort}
+              size="icon"
+              variant="destructive"
+            >
+              <Square className="size-3.5" />
+            </Button>
+          ) : (
+            <Button
+              className="size-9 shrink-0 rounded-xl"
+              disabled={!input.trim() || !isConfigured}
+              onClick={handleSubmit}
+              size="icon"
+            >
+              <Send className="size-3.5" />
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MessageBubble({ message }: { message: CopilotMessage }) {
+  if (message.role === "user") {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[85%] rounded-2xl rounded-br-md bg-emerald-600/20 px-2.5 py-1.5 text-xs text-foreground/88">
+          {message.content}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {message.toolCalls && message.toolCalls.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {message.toolCalls.map((tc) => (
+            <div
+              className="flex items-center gap-1 rounded-md bg-emerald-500/10 px-1.5 py-0.5 text-[9px] text-emerald-300"
+              key={tc.id}
+            >
+              <Wrench className="size-2" />
+              {tc.name}
+            </div>
+          ))}
+        </div>
+      )}
+      {message.content && <MarkdownContent content={message.content} />}
+    </div>
+  );
+}
+
+function MarkdownContent({ content }: { content: string }) {
+  const html = useMemo(() => renderMarkdown(content), [content]);
+
+  return (
+    <div
+      className="copilot-markdown max-w-[95%] rounded-2xl rounded-bl-md bg-white/[0.04] px-2.5 py-1.5 text-xs leading-relaxed text-foreground/72"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+function renderMarkdown(text: string): string {
+  let html = escapeHtml(text);
+
+  // headings
+  html = html.replace(/^#### (.+)$/gm, '<h4 class="mt-2 mb-0.5 text-[11px] font-semibold text-foreground/80">$1</h4>');
+  html = html.replace(/^### (.+)$/gm, '<h3 class="mt-2 mb-0.5 text-xs font-semibold text-foreground/85">$1</h3>');
+  html = html.replace(/^## (.+)$/gm, '<h2 class="mt-2 mb-0.5 text-xs font-bold text-foreground/90">$1</h2>');
+  html = html.replace(/^# (.+)$/gm, '<h1 class="mt-2 mb-0.5 text-[13px] font-bold text-foreground/92">$1</h1>');
+
+  // code blocks
+  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, _lang, code) =>
+    `<pre class="my-1 rounded-lg bg-white/[0.06] px-2 py-1.5 text-[10px] leading-snug overflow-x-auto"><code>${code.trim()}</code></pre>`
+  );
+
+  // inline code
+  html = html.replace(/`([^`]+)`/g, '<code class="rounded bg-white/[0.08] px-1 py-px text-[10px] text-emerald-200">$1</code>');
+
+  // bold
+  html = html.replace(/\*\*([^*]+)\*\*/g, '<strong class="font-semibold text-foreground/88">$1</strong>');
+
+  // italic
+  html = html.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, "<em>$1</em>");
+
+  // unordered lists
+  html = html.replace(/^[\-\*] (.+)$/gm, '<li class="ml-3 list-disc">$1</li>');
+  html = html.replace(/((?:<li[^>]*>.*<\/li>\n?)+)/g, '<ul class="my-1 space-y-0.5">$1</ul>');
+
+  // ordered lists
+  html = html.replace(/^\d+\. (.+)$/gm, '<li class="ml-3 list-decimal">$1</li>');
+  html = html.replace(/((?:<li class="ml-3 list-decimal">.*<\/li>\n?)+)/g, '<ul class="my-1 space-y-0.5">$1</ul>');
+
+  // paragraphs (double newlines)
+  html = html.replace(/\n\n+/g, '</p><p class="mt-1.5">');
+  html = `<p>${html}</p>`;
+
+  // single newlines to <br> (but not inside pre)
+  html = html.replace(/(?<!<\/pre>)\n(?!<)/g, "<br>");
+
+  return html;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function ThinkingIndicator({ session }: { session: CopilotSession }) {
+  return (
+    <div className="flex items-center gap-2 py-1">
+      <Loader2 className="size-3 animate-spin text-emerald-400" />
+      <span className="text-[10px] text-foreground/48">
+        {session.status === "executing"
+          ? "Executing tools..."
+          : `Thinking${session.iterationCount > 1 ? ` (step ${session.iterationCount})` : ""}...`}
+      </span>
+    </div>
+  );
+}

--- a/apps/editor/src/components/editor-shell/CopilotSettingsDialog.tsx
+++ b/apps/editor/src/components/editor-shell/CopilotSettingsDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Settings, Eye, EyeOff } from "lucide-react";
+import { Settings, Eye, EyeOff, CheckCircle, AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -9,24 +9,41 @@ import {
   DialogTitle,
   DialogTrigger
 } from "@/components/ui/dialog";
-import type { CopilotSettings, CopilotModelId } from "@/lib/copilot/types";
+import type { CopilotSettings, CopilotProviderId, GeminiModelId, CodexModelId } from "@/lib/copilot/types";
 import { loadCopilotSettings, saveCopilotSettings } from "@/lib/copilot/settings";
+
+type CodexStatus = { available: boolean; version?: string; error?: string } | null;
 
 export function CopilotSettingsDialog({ onSaved }: { onSaved?: () => void }) {
   const [open, setOpen] = useState(false);
   const [settings, setSettings] = useState<CopilotSettings>(loadCopilotSettings);
   const [showKey, setShowKey] = useState(false);
+  const [codexStatus, setCodexStatus] = useState<CodexStatus>(null);
 
   useEffect(() => {
     if (open) {
       setSettings(loadCopilotSettings());
+      fetchCodexStatus();
     }
   }, [open]);
+
+  const fetchCodexStatus = async () => {
+    try {
+      const res = await fetch("/api/codex/status");
+      setCodexStatus(await res.json());
+    } catch {
+      setCodexStatus({ available: false, error: "Could not check Codex status" });
+    }
+  };
 
   const handleSave = () => {
     saveCopilotSettings(settings);
     setOpen(false);
     onSaved?.();
+  };
+
+  const setProvider = (provider: CopilotProviderId) => {
+    setSettings({ ...settings, provider });
   };
 
   return (
@@ -40,49 +57,126 @@ export function CopilotSettingsDialog({ onSaved }: { onSaved?: () => void }) {
       </DialogTrigger>
       <DialogContent className="border-white/10 bg-[#0a1510] sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Copilot Settings</DialogTitle>
+          <DialogTitle>Vibe Settings</DialogTitle>
         </DialogHeader>
         <div className="space-y-4 pt-2">
+          {/* Provider selector */}
           <div className="space-y-1.5">
             <label className="text-[11px] font-medium tracking-[0.18em] text-foreground/52 uppercase">
-              API Key
+              Provider
             </label>
-            <div className="relative">
-              <Input
-                className="h-10 rounded-xl border-white/10 bg-white/[0.045] pr-10 text-sm font-mono"
-                onChange={(e) => setSettings({ ...settings, apiKey: e.target.value })}
-                placeholder="Enter your Gemini API key"
-                type={showKey ? "text" : "password"}
-                value={settings.apiKey}
-              />
+            <div className="grid grid-cols-2 gap-1.5">
               <Button
-                className="absolute right-1 top-1 size-8 rounded-lg text-foreground/48"
-                onClick={() => setShowKey(!showKey)}
-                size="icon-sm"
+                className={`h-9 rounded-xl text-xs ${settings.provider === "codex" ? "bg-emerald-500/18 text-emerald-200" : "text-foreground/60"}`}
+                onClick={() => setProvider("codex")}
                 variant="ghost"
               >
-                {showKey ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
+                Codex CLI
+              </Button>
+              <Button
+                className={`h-9 rounded-xl text-xs ${settings.provider === "gemini" ? "bg-emerald-500/18 text-emerald-200" : "text-foreground/60"}`}
+                onClick={() => setProvider("gemini")}
+                variant="ghost"
+              >
+                Gemini API
               </Button>
             </div>
-            <p className="text-[10px] text-foreground/36">
-              Stored locally in your browser. Never sent to our servers.
-            </p>
           </div>
 
-          <div className="space-y-1.5">
-            <label className="text-[11px] font-medium tracking-[0.18em] text-foreground/52 uppercase">
-              Model
-            </label>
-            <select
-              className="h-10 w-full rounded-xl border border-white/10 bg-white/[0.045] px-3 text-sm text-foreground"
-              onChange={(e) => setSettings({ ...settings, model: e.target.value as CopilotModelId })}
-              value={settings.model}
-            >
-              <option value="gemini-3-flash-preview">Gemini 3 Flash Preview</option>
-              <option value="gemini-3.1-pro-preview">Gemini 3.1 Pro Preview</option>
-            </select>
-          </div>
+          {/* Provider-specific settings */}
+          {settings.provider === "gemini" ? (
+            <>
+              <div className="space-y-1.5">
+                <label className="text-[11px] font-medium tracking-[0.18em] text-foreground/52 uppercase">
+                  API Key
+                </label>
+                <div className="relative">
+                  <Input
+                    className="h-10 rounded-xl border-white/10 bg-white/[0.045] pr-10 text-sm font-mono"
+                    onChange={(e) => setSettings({ ...settings, gemini: { ...settings.gemini, apiKey: e.target.value } })}
+                    placeholder="Enter your Gemini API key"
+                    type={showKey ? "text" : "password"}
+                    value={settings.gemini.apiKey}
+                  />
+                  <Button
+                    className="absolute right-1 top-1 size-8 rounded-lg text-foreground/48"
+                    onClick={() => setShowKey(!showKey)}
+                    size="icon-sm"
+                    variant="ghost"
+                  >
+                    {showKey ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
+                  </Button>
+                </div>
+                <p className="text-[10px] text-foreground/36">
+                  Stored locally in your browser. Never sent to our servers.
+                </p>
+              </div>
 
+              <div className="space-y-1.5">
+                <label className="text-[11px] font-medium tracking-[0.18em] text-foreground/52 uppercase">
+                  Model
+                </label>
+                <select
+                  className="h-10 w-full rounded-xl border border-white/10 bg-white/[0.045] px-3 text-sm text-foreground"
+                  onChange={(e) => setSettings({ ...settings, gemini: { ...settings.gemini, model: e.target.value as GeminiModelId } })}
+                  value={settings.gemini.model}
+                >
+                  <option value="gemini-3-flash-preview">Gemini 3 Flash Preview</option>
+                  <option value="gemini-3.1-pro-preview">Gemini 3.1 Pro Preview</option>
+                </select>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="space-y-1.5">
+                <label className="text-[11px] font-medium tracking-[0.18em] text-foreground/52 uppercase">
+                  Model
+                </label>
+                <select
+                  className="h-10 w-full rounded-xl border border-white/10 bg-white/[0.045] px-3 text-sm text-foreground"
+                  disabled={!codexStatus?.available}
+                  onChange={(e) => setSettings({ ...settings, codex: { ...settings.codex, model: e.target.value as CodexModelId } })}
+                  value={settings.codex.model}
+                >
+                  <option value="gpt-5.4">GPT-5.4 (Flagship)</option>
+                  <option value="gpt-5.3-codex">GPT-5.3 Codex</option>
+                  <option value="gpt-5.1-codex-max">GPT-5.1 Codex Max</option>
+                  <option value="gpt-4.1">GPT-4.1</option>
+                  <option value="gpt-4.1-mini">GPT-4.1 Mini</option>
+                  <option value="o3">o3 (Reasoning)</option>
+                  <option value="o4-mini">o4-mini (Reasoning)</option>
+                  <option value="codex-mini-latest">Codex Mini (Legacy)</option>
+                </select>
+              </div>
+
+              {/* Codex status */}
+              <div className="space-y-2">
+                {codexStatus === null ? (
+                  <p className="text-[11px] text-foreground/40">Checking Codex CLI...</p>
+                ) : codexStatus.available ? (
+                  <div className="flex items-center gap-2 text-[11px] text-emerald-300">
+                    <CheckCircle className="size-3.5" />
+                    Codex CLI detected {codexStatus.version ? `(${codexStatus.version})` : ""}
+                  </div>
+                ) : (
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2 text-[11px] text-amber-300">
+                      <AlertTriangle className="size-3.5" />
+                      Codex CLI not found
+                    </div>
+                    <p className="text-[10px] text-foreground/36">
+                      Install with: <code className="rounded bg-white/10 px-1 py-px text-emerald-200">npm install -g @openai/codex</code>
+                    </p>
+                  </div>
+                )}
+                <p className="text-[10px] text-foreground/36">
+                  Codex uses your local login session. Run <code className="rounded bg-white/10 px-1 py-px text-emerald-200">codex login</code> in your terminal to authenticate.
+                </p>
+              </div>
+            </>
+          )}
+
+          {/* Temperature (shared) */}
           <div className="space-y-1.5">
             <label className="text-[11px] font-medium tracking-[0.18em] text-foreground/52 uppercase">
               Temperature ({settings.temperature.toFixed(1)})
@@ -103,12 +197,7 @@ export function CopilotSettingsDialog({ onSaved }: { onSaved?: () => void }) {
           </div>
 
           <div className="flex justify-end gap-2 pt-2">
-            <Button
-              className="rounded-xl"
-              onClick={() => setOpen(false)}
-              size="sm"
-              variant="ghost"
-            >
+            <Button className="rounded-xl" onClick={() => setOpen(false)} size="sm" variant="ghost">
               Cancel
             </Button>
             <Button className="rounded-xl" onClick={handleSave} size="sm">

--- a/apps/editor/src/components/editor-shell/CopilotSettingsDialog.tsx
+++ b/apps/editor/src/components/editor-shell/CopilotSettingsDialog.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import { Settings, Eye, EyeOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from "@/components/ui/dialog";
+import type { CopilotSettings, CopilotModelId } from "@/lib/copilot/types";
+import { loadCopilotSettings, saveCopilotSettings } from "@/lib/copilot/settings";
+
+export function CopilotSettingsDialog({ onSaved }: { onSaved?: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [settings, setSettings] = useState<CopilotSettings>(loadCopilotSettings);
+  const [showKey, setShowKey] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setSettings(loadCopilotSettings());
+    }
+  }, [open]);
+
+  const handleSave = () => {
+    saveCopilotSettings(settings);
+    setOpen(false);
+    onSaved?.();
+  };
+
+  return (
+    <Dialog onOpenChange={setOpen} open={open}>
+      <DialogTrigger
+        render={
+          <Button className="size-7 rounded-lg text-foreground/48 hover:text-foreground" size="icon-sm" variant="ghost" />
+        }
+      >
+        <Settings className="size-3.5" />
+      </DialogTrigger>
+      <DialogContent className="border-white/10 bg-[#0a1510] sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Copilot Settings</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 pt-2">
+          <div className="space-y-1.5">
+            <label className="text-[11px] font-medium tracking-[0.18em] text-foreground/52 uppercase">
+              API Key
+            </label>
+            <div className="relative">
+              <Input
+                className="h-10 rounded-xl border-white/10 bg-white/[0.045] pr-10 text-sm font-mono"
+                onChange={(e) => setSettings({ ...settings, apiKey: e.target.value })}
+                placeholder="Enter your Gemini API key"
+                type={showKey ? "text" : "password"}
+                value={settings.apiKey}
+              />
+              <Button
+                className="absolute right-1 top-1 size-8 rounded-lg text-foreground/48"
+                onClick={() => setShowKey(!showKey)}
+                size="icon-sm"
+                variant="ghost"
+              >
+                {showKey ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
+              </Button>
+            </div>
+            <p className="text-[10px] text-foreground/36">
+              Stored locally in your browser. Never sent to our servers.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-[11px] font-medium tracking-[0.18em] text-foreground/52 uppercase">
+              Model
+            </label>
+            <select
+              className="h-10 w-full rounded-xl border border-white/10 bg-white/[0.045] px-3 text-sm text-foreground"
+              onChange={(e) => setSettings({ ...settings, model: e.target.value as CopilotModelId })}
+              value={settings.model}
+            >
+              <option value="gemini-3-flash-preview">Gemini 3 Flash Preview</option>
+              <option value="gemini-3.1-pro-preview">Gemini 3.1 Pro Preview</option>
+            </select>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-[11px] font-medium tracking-[0.18em] text-foreground/52 uppercase">
+              Temperature ({settings.temperature.toFixed(1)})
+            </label>
+            <input
+              className="w-full accent-emerald-400"
+              max={1}
+              min={0}
+              onChange={(e) => setSettings({ ...settings, temperature: parseFloat(e.target.value) })}
+              step={0.1}
+              type="range"
+              value={settings.temperature}
+            />
+            <div className="flex justify-between text-[10px] text-foreground/36">
+              <span>Precise</span>
+              <span>Creative</span>
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              className="rounded-xl"
+              onClick={() => setOpen(false)}
+              size="sm"
+              variant="ghost"
+            >
+              Cancel
+            </Button>
+            <Button className="rounded-xl" onClick={handleSave} size="sm">
+              Save
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/editor/src/components/editor-shell/EditorMenuBar.tsx
+++ b/apps/editor/src/components/editor-shell/EditorMenuBar.tsx
@@ -1,4 +1,4 @@
-import { Gauge } from "lucide-react";
+import { Bot, Gauge } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Menubar,
@@ -14,6 +14,7 @@ import type { ViewportQuality } from "@/state/ui-store";
 type EditorMenuBarProps = {
   canRedo: boolean;
   canUndo: boolean;
+  copilotOpen: boolean;
   onClearSelection: () => void;
   onCreateBrush: () => void;
   onDeleteSelection: () => void;
@@ -25,6 +26,7 @@ type EditorMenuBarProps = {
   onLoadWhmap: () => void;
   onRedo: () => void;
   onSaveWhmap: () => void;
+  onToggleCopilot: () => void;
   onToggleViewportQuality: () => void;
   onUndo: () => void;
   viewportQuality: ViewportQuality;
@@ -33,6 +35,7 @@ type EditorMenuBarProps = {
 export function EditorMenuBar({
   canRedo,
   canUndo,
+  copilotOpen,
   onClearSelection,
   onCreateBrush,
   onDeleteSelection,
@@ -44,6 +47,7 @@ export function EditorMenuBar({
   onLoadWhmap,
   onRedo,
   onSaveWhmap,
+  onToggleCopilot,
   onToggleViewportQuality,
   viewportQuality,
   onUndo
@@ -145,7 +149,7 @@ export function EditorMenuBar({
         </Menubar>
       </div>
 
-      <div className="flex items-center gap-1 px-2">
+      <div className="flex shrink-0 items-center gap-3 px-2">
         <Button
           aria-label={`Canvas DPR ${viewportQuality.toFixed(2)}x`}
           className="text-[11px] text-foreground/65 hover:text-foreground flex flex-row gap-1 px-2"
@@ -156,6 +160,16 @@ export function EditorMenuBar({
         >
           <Gauge className="size-3.5" />
           {viewportQuality.toFixed(2)}
+        </Button>
+        <Button
+          aria-label="AI Vibe"
+          className={`size-7 rounded-lg ${copilotOpen ? "text-emerald-400 hover:text-emerald-300" : "text-foreground/65 hover:text-foreground"}`}
+          onClick={onToggleCopilot}
+          title="AI Vibe (Cmd+L)"
+          size="icon-sm"
+          variant="ghost"
+        >
+          <Bot className="size-3.5" />
         </Button>
       </div>
     </div>

--- a/apps/editor/src/components/editor-shell/InspectorSidebar.tsx
+++ b/apps/editor/src/components/editor-shell/InspectorSidebar.tsx
@@ -35,7 +35,7 @@ import type { MeshEditToolbarActionRequest } from "@/viewport/types";
 import type { RightPanelId } from "@/state/ui-store";
 
 type InspectorSidebarProps = {
-  activeRightPanel: RightPanelId;
+  activeRightPanel: RightPanelId | null;
   activeToolId: ToolId;
   assets: Array<{ id: string; path: string; type: string }>;
   entities: Entity[];
@@ -43,7 +43,7 @@ type InspectorSidebarProps = {
   meshEditMode: MeshEditMode;
   nodes: GeometryNode[];
   onApplyMaterial: (materialId: string, scope: "faces" | "object", faceIds: string[]) => void;
-  onChangeRightPanel: (panel: RightPanelId) => void;
+  onChangeRightPanel: (panel: RightPanelId | null) => void;
   onClipSelection: (axis: "x" | "y" | "z") => void;
   onDeleteMaterial: (materialId: string) => void;
   onDeleteTexture: (textureId: string) => void;
@@ -238,41 +238,54 @@ export function InspectorSidebar({
     );
   };
 
+  const handleTabClick = (panel: RightPanelId) => {
+    if (activeRightPanel === panel) {
+      onChangeRightPanel(null);
+    } else {
+      onChangeRightPanel(panel);
+    }
+  };
+
+  const collapsed = activeRightPanel === null;
+
   return (
-    <div className="pointer-events-none absolute right-4 top-4 z-20 flex h-[clamp(26rem,58vh,42rem)] w-88 max-h-[calc(100%-7rem)]">
+    <div className={cn(
+      "pointer-events-none absolute right-4 top-4 z-20 flex w-88 max-h-[calc(100%-7rem)]",
+      collapsed ? "h-auto" : "h-[clamp(26rem,58vh,42rem)]"
+    )}>
       <FloatingPanel className="flex min-h-0 w-full flex-col overflow-hidden">
         <Tabs
           className="flex min-h-0 flex-1 flex-col gap-0"
           onValueChange={(value) => onChangeRightPanel(value as RightPanelId)}
-          value={activeRightPanel}
+          value={activeRightPanel ?? ""}
         >
-          <div className="px-3 pt-3 pb-2">
+          <div className={cn("px-3 pt-3", collapsed ? "pb-3" : "pb-2")}>
             <TabsList className="!grid !h-14 !w-full !grid-cols-7 !items-stretch rounded-xl bg-white/5 p-0.5" variant="default">
-              <TabsTrigger className={cn(RIGHT_PANEL_TAB_TRIGGER_CLASS, "!flex-col")} value="scene">
+              <TabsTrigger className={cn(RIGHT_PANEL_TAB_TRIGGER_CLASS, "!flex-col")} value="scene" onClick={() => handleTabClick("scene")}>
                 <FolderTree />
                 <span className={RIGHT_PANEL_TAB_LABEL_CLASS}>Scene</span>
               </TabsTrigger>
-              <TabsTrigger className={cn(RIGHT_PANEL_TAB_TRIGGER_CLASS, "!flex-col")} value="world">
+              <TabsTrigger className={cn(RIGHT_PANEL_TAB_TRIGGER_CLASS, "!flex-col")} value="world" onClick={() => handleTabClick("world")}>
                 <Globe2 />
                 <span className={RIGHT_PANEL_TAB_LABEL_CLASS}>World</span>
               </TabsTrigger>
-              <TabsTrigger className={cn(RIGHT_PANEL_TAB_TRIGGER_CLASS, "!flex-col")} value="player">
+              <TabsTrigger className={cn(RIGHT_PANEL_TAB_TRIGGER_CLASS, "!flex-col")} value="player" onClick={() => handleTabClick("player")}>
                 <User />
                 <span className={RIGHT_PANEL_TAB_LABEL_CLASS}>Player</span>
               </TabsTrigger>
-              <TabsTrigger className={cn(RIGHT_PANEL_TAB_TRIGGER_CLASS, "!flex-col")} value="inspector">
+              <TabsTrigger className={cn(RIGHT_PANEL_TAB_TRIGGER_CLASS, "!flex-col")} value="inspector" onClick={() => handleTabClick("inspector")}>
                 <SlidersHorizontal />
                 <span className={RIGHT_PANEL_TAB_LABEL_CLASS}>Inspect</span>
               </TabsTrigger>
-              <TabsTrigger className={cn(RIGHT_PANEL_TAB_TRIGGER_CLASS, "!flex-col")} value="hooks">
+              <TabsTrigger className={cn(RIGHT_PANEL_TAB_TRIGGER_CLASS, "!flex-col")} value="hooks" onClick={() => handleTabClick("hooks")}>
                 <Cable />
                 <span className={RIGHT_PANEL_TAB_LABEL_CLASS}>Hooks</span>
               </TabsTrigger>
-              <TabsTrigger className={cn(RIGHT_PANEL_TAB_TRIGGER_CLASS, "!flex-col")} value="events">
+              <TabsTrigger className={cn(RIGHT_PANEL_TAB_TRIGGER_CLASS, "!flex-col")} value="events" onClick={() => handleTabClick("events")}>
                 <BellRing />
                 <span className={RIGHT_PANEL_TAB_LABEL_CLASS}>Events</span>
               </TabsTrigger>
-              <TabsTrigger className={cn(RIGHT_PANEL_TAB_TRIGGER_CLASS, "!flex-col")} value="materials">
+              <TabsTrigger className={cn(RIGHT_PANEL_TAB_TRIGGER_CLASS, "!flex-col")} value="materials" onClick={() => handleTabClick("materials")}>
                 <SwatchBook />
                 <span className={RIGHT_PANEL_TAB_LABEL_CLASS}>Mats</span>
               </TabsTrigger>

--- a/apps/editor/src/lib/copilot/agentic-loop.ts
+++ b/apps/editor/src/lib/copilot/agentic-loop.ts
@@ -1,0 +1,190 @@
+import type {
+  CopilotMessage,
+  CopilotProvider,
+  CopilotProviderConfig,
+  CopilotSession,
+  CopilotToolCall,
+  CopilotToolDeclaration,
+  CopilotToolResult
+} from "./types";
+
+export type AgenticLoopConfig = {
+  maxIterations: number;
+  provider: CopilotProvider;
+  providerConfig: CopilotProviderConfig;
+  systemPrompt: string;
+  tools: CopilotToolDeclaration[];
+  executeTool: (call: CopilotToolCall) => CopilotToolResult;
+  onUpdate: (session: CopilotSession) => void;
+};
+
+function uid(): string {
+  return `msg_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const TAG = "[AI-VIBE]";
+
+export async function runAgenticLoop(
+  userPrompt: string,
+  existingMessages: CopilotMessage[],
+  config: AgenticLoopConfig,
+  signal?: AbortSignal
+): Promise<CopilotSession> {
+  console.group(`${TAG} Session start`);
+  console.log(`${TAG} User prompt:`, userPrompt);
+  console.log(`${TAG} Model:`, config.providerConfig.model);
+  console.log(`${TAG} Temperature:`, config.providerConfig.temperature);
+  console.log(`${TAG} Tools available:`, config.tools.map((t) => t.name));
+  console.log(`${TAG} System prompt:\n`, config.systemPrompt);
+  console.log(`${TAG} Existing messages:`, existingMessages.length);
+  console.groupEnd();
+
+  const messages: CopilotMessage[] = [
+    ...existingMessages,
+    {
+      id: uid(),
+      role: "user",
+      content: userPrompt,
+      timestamp: Date.now()
+    }
+  ];
+
+  const session: CopilotSession = {
+    messages,
+    status: "thinking",
+    iterationCount: 0
+  };
+
+  config.onUpdate({ ...session, messages: [...messages] });
+
+  for (let iteration = 0; iteration < config.maxIterations; iteration++) {
+    if (signal?.aborted) {
+      console.log(`${TAG} Aborted at iteration ${iteration + 1}`);
+      session.status = "aborted";
+      config.onUpdate({ ...session, messages: [...messages] });
+      return session;
+    }
+
+    session.status = "thinking";
+    session.iterationCount = iteration + 1;
+    config.onUpdate({ ...session, messages: [...messages] });
+
+    console.group(`${TAG} Iteration ${iteration + 1}`);
+    console.log(`${TAG} Sending ${messages.length} messages to LLM...`);
+
+    let response;
+
+    try {
+      const t0 = performance.now();
+      response = await config.provider.generateContent(
+        messages,
+        config.tools,
+        config.systemPrompt,
+        config.providerConfig,
+        signal
+      );
+      const elapsed = Math.round(performance.now() - t0);
+      console.log(`${TAG} LLM responded in ${elapsed}ms`);
+    } catch (error) {
+      console.error(`${TAG} LLM error:`, error);
+      console.groupEnd();
+
+      if (error instanceof DOMException && error.name === "AbortError") {
+        session.status = "aborted";
+        config.onUpdate({ ...session, messages: [...messages] });
+        return session;
+      }
+
+      const errorMessage = error instanceof Error ? error.message : "Unknown API error";
+      session.status = "error";
+      session.error = errorMessage;
+      config.onUpdate({ ...session, messages: [...messages] });
+      return session;
+    }
+
+    if (!response.toolCalls || response.toolCalls.length === 0) {
+      console.log(`${TAG} Final text response:`, response.text);
+      console.groupEnd();
+
+      messages.push({
+        id: uid(),
+        role: "assistant",
+        content: response.text,
+        rawParts: response.rawParts,
+        timestamp: Date.now()
+      });
+      session.status = "idle";
+      session.messages = messages;
+      config.onUpdate({ ...session, messages: [...messages] });
+      return session;
+    }
+
+    console.log(`${TAG} Text:`, response.text || "(none)");
+    console.log(`${TAG} Tool calls (${response.toolCalls.length}):`);
+    for (const tc of response.toolCalls) {
+      console.log(`  ${TAG} → ${tc.name}`, JSON.stringify(tc.args, null, 2));
+    }
+
+    messages.push({
+      id: uid(),
+      role: "assistant",
+      content: response.text,
+      toolCalls: response.toolCalls,
+      rawParts: response.rawParts,
+      timestamp: Date.now()
+    });
+
+    session.status = "executing";
+    config.onUpdate({ ...session, messages: [...messages] });
+
+    const toolResults: CopilotToolResult[] = [];
+
+    for (const toolCall of response.toolCalls) {
+      if (signal?.aborted) {
+        console.log(`${TAG} Aborted during tool execution`);
+        console.groupEnd();
+        session.status = "aborted";
+        config.onUpdate({ ...session, messages: [...messages] });
+        return session;
+      }
+
+      const t0 = performance.now();
+      const result = config.executeTool(toolCall);
+      const elapsed = Math.round(performance.now() - t0);
+
+      const parsed = JSON.parse(result.result);
+      if (parsed.success === false) {
+        console.warn(`  ${TAG} ✗ ${toolCall.name} FAILED (${elapsed}ms):`, parsed.error);
+      } else {
+        console.log(`  ${TAG} ✓ ${toolCall.name} (${elapsed}ms):`, result.result);
+      }
+
+      toolResults.push(result);
+    }
+
+    messages.push({
+      id: uid(),
+      role: "tool",
+      content: "",
+      toolResults,
+      timestamp: Date.now()
+    });
+
+    console.groupEnd();
+    config.onUpdate({ ...session, messages: [...messages] });
+  }
+
+  console.warn(`${TAG} Hit max iterations (${config.maxIterations})`);
+
+  messages.push({
+    id: uid(),
+    role: "assistant",
+    content: "Reached maximum iterations. Stopping here.",
+    timestamp: Date.now()
+  });
+
+  session.status = "idle";
+  session.messages = messages;
+  config.onUpdate({ ...session, messages: [...messages] });
+  return session;
+}

--- a/apps/editor/src/lib/copilot/codex-provider.ts
+++ b/apps/editor/src/lib/copilot/codex-provider.ts
@@ -1,0 +1,221 @@
+import type {
+  CopilotMessage,
+  CopilotSession,
+  CopilotToolCall,
+  CopilotToolDeclaration,
+  CopilotToolResult,
+  SessionBasedCopilotProvider
+} from "./types";
+import type { CodexWsServerMessage } from "./codex-ws-protocol";
+
+const TAG = "[AI-VIBE:CODEX]";
+
+function uid(): string {
+  return `msg_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function createCodexProvider(): SessionBasedCopilotProvider {
+  return {
+    async runSession(config): Promise<CopilotSession> {
+      const messages: CopilotMessage[] = [
+        ...config.messages,
+        { id: uid(), role: "user", content: config.userPrompt, timestamp: Date.now() }
+      ];
+
+      const session: CopilotSession = {
+        messages,
+        status: "thinking",
+        iterationCount: 0
+      };
+
+      config.onUpdate({ ...session, messages: [...messages] });
+
+      const wsTools = config.tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.parameters
+      }));
+
+      console.group(`${TAG} Session start`);
+      console.log(`${TAG} Model:`, config.providerConfig.model);
+      console.log(`${TAG} User prompt:`, config.userPrompt);
+      console.log(`${TAG} Tools:`, wsTools.length);
+      console.groupEnd();
+
+      return new Promise<CopilotSession>((resolve) => {
+        const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+        const ws = new WebSocket(`${protocol}//${location.host}/ws/codex`);
+
+        let agentText = "";
+        const toolCalls: CopilotToolCall[] = [];
+        let aborted = false;
+
+        const handleAbort = () => {
+          aborted = true;
+          ws.send(JSON.stringify({ type: "abort" }));
+          ws.close();
+          session.status = "aborted";
+          config.onUpdate({ ...session, messages: [...messages] });
+          resolve(session);
+        };
+
+        config.signal?.addEventListener("abort", handleAbort, { once: true });
+
+        ws.onopen = () => {
+          console.log(`${TAG} WebSocket connected, sending start message`);
+          ws.send(JSON.stringify({
+            type: "start",
+            model: config.providerConfig.model,
+            systemPrompt: config.systemPrompt,
+            tools: wsTools,
+            userMessage: config.userPrompt
+          }));
+        };
+
+        ws.onmessage = (event) => {
+          if (aborted) return;
+
+          const msg = JSON.parse(event.data) as CodexWsServerMessage;
+
+          switch (msg.type) {
+            case "status": {
+              if (msg.status === "thinking") session.status = "thinking";
+              else if (msg.status === "executing") session.status = "executing";
+              config.onUpdate({ ...session, messages: [...messages] });
+              break;
+            }
+
+            case "delta": {
+              agentText += msg.text;
+              break;
+            }
+
+            case "tool_call": {
+              console.log(`  ${TAG} → ${msg.name}`, JSON.stringify(msg.args, null, 2));
+              session.status = "executing";
+              session.iterationCount++;
+
+              const toolCall: CopilotToolCall = {
+                id: msg.id,
+                name: msg.name,
+                args: msg.args
+              };
+              toolCalls.push(toolCall);
+
+              // Push assistant message with this tool call for UI
+              messages.push({
+                id: uid(),
+                role: "assistant",
+                content: "",
+                toolCalls: [toolCall],
+                timestamp: Date.now()
+              });
+              config.onUpdate({ ...session, messages: [...messages] });
+
+              // Execute the tool browser-side
+              const t0 = performance.now();
+              const result = config.executeTool(toolCall);
+              const elapsed = Math.round(performance.now() - t0);
+
+              const parsed = JSON.parse(result.result);
+              if (parsed.success === false) {
+                console.warn(`  ${TAG} ✗ ${msg.name} FAILED (${elapsed}ms):`, parsed.error);
+              } else {
+                console.log(`  ${TAG} ✓ ${msg.name} (${elapsed}ms):`, result.result);
+              }
+
+              // Push tool result message
+              messages.push({
+                id: uid(),
+                role: "tool",
+                content: "",
+                toolResults: [result],
+                timestamp: Date.now()
+              });
+
+              // Send result back to server
+              ws.send(JSON.stringify({
+                type: "tool_result",
+                id: msg.id,
+                result: result.result,
+                success: parsed.success !== false
+              }));
+
+              session.status = "thinking";
+              config.onUpdate({ ...session, messages: [...messages] });
+              break;
+            }
+
+            case "tool_status": {
+              // Tool completed/failed on codex side — already handled in tool_call flow
+              break;
+            }
+
+            case "turn_complete": {
+              console.log(`${TAG} Turn complete. Agent text:`, msg.text || agentText);
+              const finalText = msg.text || agentText;
+
+              if (finalText) {
+                messages.push({
+                  id: uid(),
+                  role: "assistant",
+                  content: finalText,
+                  timestamp: Date.now()
+                });
+              }
+
+              session.status = "idle";
+              session.messages = messages;
+              config.onUpdate({ ...session, messages: [...messages] });
+              config.signal?.removeEventListener("abort", handleAbort);
+              ws.close();
+              resolve(session);
+              break;
+            }
+
+            case "auth_required": {
+              session.status = "error";
+              session.error = msg.message || 'Not authenticated. Run "codex login" in your terminal.';
+              config.onUpdate({ ...session, messages: [...messages] });
+              config.signal?.removeEventListener("abort", handleAbort);
+              ws.close();
+              resolve(session);
+              break;
+            }
+
+            case "error": {
+              console.error(`${TAG} Error:`, msg.message);
+              session.status = "error";
+              session.error = msg.message;
+              config.onUpdate({ ...session, messages: [...messages] });
+              if (msg.fatal) {
+                config.signal?.removeEventListener("abort", handleAbort);
+                ws.close();
+                resolve(session);
+              }
+              break;
+            }
+          }
+        };
+
+        ws.onerror = () => {
+          if (aborted) return;
+          session.status = "error";
+          session.error = "WebSocket connection failed. Is the dev server running?";
+          config.onUpdate({ ...session, messages: [...messages] });
+          config.signal?.removeEventListener("abort", handleAbort);
+          resolve(session);
+        };
+
+        ws.onclose = () => {
+          if (aborted || session.status === "idle" || session.status === "error") return;
+          session.status = "error";
+          session.error = "Connection closed unexpectedly";
+          config.onUpdate({ ...session, messages: [...messages] });
+          config.signal?.removeEventListener("abort", handleAbort);
+          resolve(session);
+        };
+      });
+    }
+  };
+}

--- a/apps/editor/src/lib/copilot/codex-ws-protocol.ts
+++ b/apps/editor/src/lib/copilot/codex-ws-protocol.ts
@@ -1,0 +1,31 @@
+// Shared WebSocket message types for browser ↔ Vite server communication
+// The Vite server bridges these to/from the codex app-server JSON-RPC protocol
+
+// Browser → Server
+export type CodexWsClientMessage =
+  | {
+      type: "start";
+      model: string;
+      systemPrompt: string;
+      tools: Array<{ name: string; description: string; inputSchema: Record<string, unknown> }>;
+      userMessage: string;
+    }
+  | {
+      type: "tool_result";
+      id: string;
+      result: string;
+      success: boolean;
+    }
+  | {
+      type: "abort";
+    };
+
+// Server → Browser
+export type CodexWsServerMessage =
+  | { type: "status"; status: "connecting" | "thinking" | "executing" }
+  | { type: "delta"; text: string }
+  | { type: "tool_call"; id: string; name: string; args: Record<string, unknown> }
+  | { type: "tool_status"; id: string; name: string; status: "completed" | "failed" }
+  | { type: "turn_complete"; text: string }
+  | { type: "auth_required"; message: string }
+  | { type: "error"; message: string; fatal: boolean };

--- a/apps/editor/src/lib/copilot/gemini-provider.ts
+++ b/apps/editor/src/lib/copilot/gemini-provider.ts
@@ -1,0 +1,116 @@
+import { FunctionCallingConfigMode, GoogleGenAI } from "@google/genai";
+import type {
+  CopilotMessage,
+  CopilotProvider,
+  CopilotProviderConfig,
+  CopilotResponse,
+  CopilotToolCall,
+  CopilotToolDeclaration
+} from "./types";
+
+function convertMessages(messages: CopilotMessage[]) {
+  const contents: Record<string, unknown>[] = [];
+
+  for (const message of messages) {
+    if (message.role === "user") {
+      contents.push({ role: "user", parts: [{ text: message.content }] });
+    } else if (message.role === "assistant") {
+      // Replay raw parts verbatim to preserve thoughtSignature
+      if (message.rawParts && message.rawParts.length > 0) {
+        contents.push({ role: "model", parts: message.rawParts });
+      } else {
+        const parts: Record<string, unknown>[] = [];
+
+        if (message.content) {
+          parts.push({ text: message.content });
+        }
+
+        if (message.toolCalls) {
+          for (const tc of message.toolCalls) {
+            parts.push({ functionCall: { name: tc.name, args: tc.args } });
+          }
+        }
+
+        if (parts.length > 0) {
+          contents.push({ role: "model", parts });
+        }
+      }
+    } else if (message.role === "tool" && message.toolResults) {
+      const parts = message.toolResults.map((tr) => ({
+        functionResponse: {
+          name: tr.name,
+          response: JSON.parse(tr.result) as Record<string, unknown>
+        }
+      }));
+
+      contents.push({ role: "user", parts });
+    }
+  }
+
+  return contents;
+}
+
+function convertToolDeclarations(tools: CopilotToolDeclaration[]) {
+  return tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    parameters: tool.parameters
+  }));
+}
+
+export function createGeminiProvider(): CopilotProvider {
+  return {
+    async generateContent(
+      messages: CopilotMessage[],
+      tools: CopilotToolDeclaration[],
+      systemPrompt: string,
+      config: CopilotProviderConfig,
+      signal?: AbortSignal
+    ): Promise<CopilotResponse> {
+      const ai = new GoogleGenAI({ apiKey: config.apiKey });
+      const contents = convertMessages(messages);
+
+      const response = await ai.models.generateContent({
+        model: config.model,
+        contents,
+        config: {
+          systemInstruction: systemPrompt,
+          temperature: config.temperature,
+          tools: [{ functionDeclarations: convertToolDeclarations(tools) }],
+          toolConfig: {
+            functionCallingConfig: {
+              mode: FunctionCallingConfigMode.AUTO
+            }
+          }
+        }
+      });
+
+      if (signal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+
+      // Extract raw parts from the response to preserve thoughtSignature
+      const rawParts: unknown[] =
+        (response.candidates?.[0]?.content?.parts as unknown[]) ?? [];
+
+      const toolCalls: CopilotToolCall[] = [];
+      const functionCalls = response.functionCalls;
+
+      if (functionCalls) {
+        for (const fc of functionCalls) {
+          toolCalls.push({
+            id: `tc_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+            name: fc.name ?? "",
+            args: (fc.args as Record<string, unknown>) ?? {}
+          });
+        }
+      }
+
+      return {
+        text: response.text ?? "",
+        toolCalls,
+        rawParts
+      };
+    }
+  };
+}

--- a/apps/editor/src/lib/copilot/provider.ts
+++ b/apps/editor/src/lib/copilot/provider.ts
@@ -1,6 +1,12 @@
-import type { CopilotProvider } from "./types";
+import type { AnyCopilotProvider, CopilotProviderId } from "./types";
 import { createGeminiProvider } from "./gemini-provider";
+import { createCodexProvider } from "./codex-provider";
 
-export function createCopilotProvider(_providerId?: string): CopilotProvider {
-  return createGeminiProvider();
+export function createCopilotProvider(providerId: CopilotProviderId): AnyCopilotProvider {
+  switch (providerId) {
+    case "codex":
+      return { kind: "session-based", provider: createCodexProvider() };
+    default:
+      return { kind: "request-response", provider: createGeminiProvider() };
+  }
 }

--- a/apps/editor/src/lib/copilot/provider.ts
+++ b/apps/editor/src/lib/copilot/provider.ts
@@ -1,0 +1,6 @@
+import type { CopilotProvider } from "./types";
+import { createGeminiProvider } from "./gemini-provider";
+
+export function createCopilotProvider(_providerId?: string): CopilotProvider {
+  return createGeminiProvider();
+}

--- a/apps/editor/src/lib/copilot/settings.ts
+++ b/apps/editor/src/lib/copilot/settings.ts
@@ -1,33 +1,48 @@
-import type { CopilotSettings } from "./types";
+import type { CopilotProviderId, CopilotSettings, CodexModelId, GeminiModelId } from "./types";
 
 const STORAGE_KEY = "web-hammer:copilot";
 
+const GEMINI_MODELS: GeminiModelId[] = ["gemini-3-flash-preview", "gemini-3.1-pro-preview"];
+const CODEX_MODELS: CodexModelId[] = ["gpt-5.4", "gpt-5.3-codex", "gpt-5.1-codex-max", "gpt-4.1", "gpt-4.1-mini", "codex-mini-latest", "o3", "o4-mini"];
+
 const DEFAULT_SETTINGS: CopilotSettings = {
-  apiKey: "",
-  model: "gemini-3-flash-preview",
+  provider: "codex",
+  gemini: { apiKey: "", model: "gemini-3-flash-preview" },
+  codex: { model: "gpt-5.4" },
   temperature: 0.3
 };
 
 export function loadCopilotSettings(): CopilotSettings {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_SETTINGS };
 
-    if (!raw) {
-      return { ...DEFAULT_SETTINGS };
+    const parsed = JSON.parse(raw);
+
+    // Migration: detect old flat format { apiKey, model, temperature }
+    if (typeof parsed.apiKey === "string" && !parsed.provider) {
+      return {
+        provider: "gemini",
+        gemini: {
+          apiKey: parsed.apiKey,
+          model: isGeminiModel(parsed.model) ? parsed.model : DEFAULT_SETTINGS.gemini.model
+        },
+        codex: { ...DEFAULT_SETTINGS.codex },
+        temperature: validTemperature(parsed.temperature)
+      };
     }
 
-    const parsed = JSON.parse(raw) as Partial<CopilotSettings>;
-
+    // New format
     return {
-      apiKey: typeof parsed.apiKey === "string" ? parsed.apiKey : DEFAULT_SETTINGS.apiKey,
-      model:
-        parsed.model === "gemini-3-flash-preview" || parsed.model === "gemini-3.1-pro-preview"
-          ? parsed.model
-          : DEFAULT_SETTINGS.model,
-      temperature:
-        typeof parsed.temperature === "number" && parsed.temperature >= 0 && parsed.temperature <= 1
-          ? parsed.temperature
-          : DEFAULT_SETTINGS.temperature
+      provider: isValidProvider(parsed.provider) ? parsed.provider : DEFAULT_SETTINGS.provider,
+      gemini: {
+        apiKey: typeof parsed.gemini?.apiKey === "string" ? parsed.gemini.apiKey : DEFAULT_SETTINGS.gemini.apiKey,
+        model: isGeminiModel(parsed.gemini?.model) ? parsed.gemini.model : DEFAULT_SETTINGS.gemini.model
+      },
+      codex: {
+        model: isCodexModel(parsed.codex?.model) ? parsed.codex.model : DEFAULT_SETTINGS.codex.model
+      },
+      temperature: validTemperature(parsed.temperature)
     };
   } catch {
     return { ...DEFAULT_SETTINGS };
@@ -38,6 +53,30 @@ export function saveCopilotSettings(settings: CopilotSettings): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
 }
 
-export function hasCopilotApiKey(): boolean {
-  return loadCopilotSettings().apiKey.length > 0;
+export function isCopilotConfigured(settings?: CopilotSettings): boolean {
+  const s = settings ?? loadCopilotSettings();
+
+  if (s.provider === "gemini") {
+    return s.gemini.apiKey.length > 0;
+  }
+
+  // Codex uses local login — always "configured" from the browser's perspective
+  // (auth is checked server-side on connect)
+  return true;
+}
+
+function isValidProvider(v: unknown): v is CopilotProviderId {
+  return v === "gemini" || v === "codex";
+}
+
+function isGeminiModel(v: unknown): v is GeminiModelId {
+  return typeof v === "string" && (GEMINI_MODELS as string[]).includes(v);
+}
+
+function isCodexModel(v: unknown): v is CodexModelId {
+  return typeof v === "string" && (CODEX_MODELS as string[]).includes(v);
+}
+
+function validTemperature(v: unknown): number {
+  return typeof v === "number" && v >= 0 && v <= 1 ? v : DEFAULT_SETTINGS.temperature;
 }

--- a/apps/editor/src/lib/copilot/settings.ts
+++ b/apps/editor/src/lib/copilot/settings.ts
@@ -1,0 +1,43 @@
+import type { CopilotSettings } from "./types";
+
+const STORAGE_KEY = "web-hammer:copilot";
+
+const DEFAULT_SETTINGS: CopilotSettings = {
+  apiKey: "",
+  model: "gemini-3-flash-preview",
+  temperature: 0.3
+};
+
+export function loadCopilotSettings(): CopilotSettings {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+
+    if (!raw) {
+      return { ...DEFAULT_SETTINGS };
+    }
+
+    const parsed = JSON.parse(raw) as Partial<CopilotSettings>;
+
+    return {
+      apiKey: typeof parsed.apiKey === "string" ? parsed.apiKey : DEFAULT_SETTINGS.apiKey,
+      model:
+        parsed.model === "gemini-3-flash-preview" || parsed.model === "gemini-3.1-pro-preview"
+          ? parsed.model
+          : DEFAULT_SETTINGS.model,
+      temperature:
+        typeof parsed.temperature === "number" && parsed.temperature >= 0 && parsed.temperature <= 1
+          ? parsed.temperature
+          : DEFAULT_SETTINGS.temperature
+    };
+  } catch {
+    return { ...DEFAULT_SETTINGS };
+  }
+}
+
+export function saveCopilotSettings(settings: CopilotSettings): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+}
+
+export function hasCopilotApiKey(): boolean {
+  return loadCopilotSettings().apiKey.length > 0;
+}

--- a/apps/editor/src/lib/copilot/system-prompt.ts
+++ b/apps/editor/src/lib/copilot/system-prompt.ts
@@ -1,0 +1,156 @@
+import type { EditorCore } from "@web-hammer/editor-core";
+
+export function buildSystemPrompt(editor: EditorCore): string {
+  const materials = Array.from(editor.scene.materials.values());
+  const nodes = Array.from(editor.scene.nodes.values());
+  const entities = Array.from(editor.scene.entities.values());
+
+  const materialsList = materials
+    .map((m) => `  - ${m.id} — "${m.name}" (${m.color})`)
+    .join("\n");
+
+  const nodeCount = nodes.length;
+  const entityCount = entities.length;
+
+  let sceneSummary: string;
+
+  if (nodeCount <= 50) {
+    const nodeLines = nodes
+      .map((n) => {
+        const p = n.transform.position;
+        return `  - [${n.id}] "${n.name}" (${n.kind}) at (${p.x}, ${p.y}, ${p.z})`;
+      })
+      .join("\n");
+    const entityLines = entities
+      .map((e) => {
+        const p = e.transform.position;
+        return `  - [${e.id}] "${e.name}" (${e.type}) at (${p.x}, ${p.y}, ${p.z})`;
+      })
+      .join("\n");
+
+    sceneSummary = [
+      `Current scene: ${nodeCount} nodes, ${entityCount} entities.`,
+      nodeCount > 0 ? `\nNodes:\n${nodeLines}` : "",
+      entityCount > 0 ? `\nEntities:\n${entityLines}` : ""
+    ].join("");
+  } else {
+    const kindCounts: Record<string, number> = {};
+
+    for (const n of nodes) {
+      kindCounts[n.kind] = (kindCounts[n.kind] ?? 0) + 1;
+    }
+
+    const breakdown = Object.entries(kindCounts)
+      .map(([kind, count]) => `${count} ${kind}`)
+      .join(", ");
+
+    sceneSummary = `Current scene: ${nodeCount} nodes (${breakdown}), ${entityCount} entities. Use list_nodes and list_entities to explore.`;
+  }
+
+  return `You are an expert level designer for Trident, a browser-based Source-2-style level editor.
+You build game levels by calling tools. Each tool call is one undoable action. Think like an architect — plan spatially, then build methodically.
+
+## Coordinate System
+- Y-up, right-handed. Units = meters.
+- Y = up, X = east/west, Z = north/south. Ground = Y=0.
+- Player height: 1.8m. Door: 1m wide × 2m tall. Step: 0.2m rise × 0.3m tread.
+
+## How Geometry Works
+- **place_blockout_room**: Creates a closed box (walls + floor + ceiling). Position is the CENTER of the floor. A room at (0, 0, 0) with size (10, 3, 8) creates walls from X:-5 to X:5, floor at Y:0, ceiling at Y:3, Z:-4 to Z:4. Set openSides to remove walls for doorways/connections.
+- **place_blockout_platform**: A solid slab. Position is the CENTER of the volume. A floor slab: position y = thickness/2 (e.g. 0.5m thick slab → y=0.25).
+- **place_blockout_stairs**: Position is center-bottom of the bottom landing. Returns topLandingCenter for chaining.
+- **place_primitive**: Simple shapes (cube, sphere, cylinder, cone). Position is the CENTER of the shape. A 1m cube at y=0.5 sits on the ground.
+- **place_brush**: Custom-sized axis-aligned box. Position is CENTER.
+
+## Critical Spatial Rules
+- Rooms are CLOSED SHELLS — walls have thickness built in. Do NOT place extra brushes for walls of a room.
+- Roofs are NOT needed — rooms already have ceilings. Only add platforms as roofs for outdoor structures.
+
+## Connecting Rooms (CRITICAL — no gaps allowed)
+To connect rooms, their shared wall must be at the EXACT same coordinate. Use this formula:
+
+**East-west connection**: Room A east wall = Room B west wall.
+  Room A at x=Ax, sizeX=Aw → east wall at Ax + Aw/2.
+  Room B x position = Ax + Aw/2 + Bw/2, where Bw = Room B sizeX.
+  Set Room A openSides includes "east", Room B openSides includes "west".
+
+**North-south connection**: Room A south wall = Room B north wall.
+  Room A at z=Az, sizeZ=Ad → south wall at Az + Ad/2.
+  Room B z position = Az + Ad/2 + Bd/2, where Bd = Room B sizeZ.
+  Set Room A openSides includes "south", Room B openSides includes "north".
+
+**Example**: Room A at (0, 0, 0) sizeX=6 → east wall at x=3.
+  Room B sizeX=4 → Room B x = 3 + 2 = 5. So place Room B at x=5.
+  Room A openSides:["east"], Room B openSides:["west"]. Zero gap.
+
+## Placing Objects Inside Rooms (IMPORTANT — follow exactly)
+Objects (furniture, props, lights) MUST be placed INSIDE the room they belong to. Calculate positions from the room's bounds:
+
+**Formula**: A room at (rx, 0, rz) with size (sx, sy, sz) occupies:
+  X: [rx - sx/2, rx + sx/2]   Z: [rz - sz/2, rz + sz/2]   Y: [0, sy]
+
+**Rules**:
+- Keep objects 0.3m from walls: usable X is [rx - sx/2 + 0.3, rx + sx/2 - 0.3], same for Z.
+- Object on the floor: set y = objectHeight / 2.
+- Object on a surface (e.g. item on a table): y = surfaceTop + objectHeight / 2.
+- Light near ceiling: y = roomHeight - 0.3.
+- Against a wall: offset only the axis touching the wall, keep the other axis centered or arranged.
+
+**Example**: Room at (5, 0, 0), size (6, 3, 4). Interior X: [2.3, 7.7], Z: [-1.7, 1.7].
+  Object (1×0.8×1) against east wall: x=7.2, y=0.4, z=0.
+  Ceiling light: x=5, y=2.7, z=0.
+
+## Material Workflow
+- create_material generates a PREDICTABLE id: 'material:custom:<slug>' where slug = lowercase name with hyphens.
+  Example: name "Dark Wood" → id "material:custom:dark-wood". You can use this id immediately.
+- FIRST create all materials you need, THEN place primitives with materialId set directly.
+  place_primitive accepts a materialId parameter — use it to set materials at creation time instead of separate assign_material calls. This is more efficient.
+- Use existing materials when they fit (see Available Materials below).
+- For rooms/brushes, use assign_material_to_brushes or assign_material after placement.
+
+## Planning Strategy
+Work in logical phases. Each phase should complete before the next:
+1. **Structure**: The main geometry — rooms, platforms, corridors, stairs, terrain, walls, outdoor areas.
+2. **Lighting**: Illuminate the scene — point lights inside enclosed spaces, directional for sun/moonlight, ambient for fill.
+3. **Materials**: Create custom materials, then assign to geometry. Do this AFTER structure so you have node IDs.
+4. **Details & props**: Smaller objects placed inside or on top of structures. Always compute position from parent structure bounds.
+5. **Entities**: Spawn points, NPCs, interactive objects.
+
+You MUST complete ALL 5 phases — do not stop after placing rooms. A scene with just rooms and no furniture/lights is incomplete.
+Within each phase, batch related tools together (e.g. place all rooms in one call, all lights in one call).
+Between phases, wait for results before proceeding — you need the returned IDs for subsequent phases.
+Avoid unnecessary list_nodes calls — only query when you need IDs you don't already have from tool results.
+
+## Available Materials
+${materialsList || "  (no materials in scene)"}
+
+## Scene State
+${sceneSummary}
+
+## Visual Quality Tips
+- Use DISTINCT, contrasting colors for different materials — avoid all-grey scenes. Use warm browns for wood, whites for walls, greens/blues for accents.
+- Make rooms generously sized — at least 6m×5m for small rooms, 8m+ for main areas. Cramped rooms look bad.
+- Use VARIED shapes for visual interest:
+  - Cube: tables, sofas, beds, counters, TV screens, shelves, cabinets
+  - Cylinder: lamp bases, pillars, plant pots, bar stools, pipes
+  - Sphere: decorative orbs, globe lights
+  - Cone: lamp shades, decorative elements
+- Realistic proportions: sofa ~2m×0.8m×0.8m, table ~1.2m×0.75m×0.8m, bed ~2m×0.5m×1.5m, chair ~0.5m×0.5m×0.5m, lamp base ~0.15m cylinder.
+- Room walls face INWARD (visible from inside). The editor camera views from above/outside.
+- ALWAYS include "top" in openSides for ALL rooms. This creates a "dollhouse" view — walls visible, no ceiling blocking the camera. Example: openSides: ["top", "south"] for a room with a south doorway.
+- Place a foundation platform under the entire structure for visual grounding (e.g. a concrete slab 0.2m thick).
+
+## Quality Expectations
+When asked for "detail" or "full detail", aim high:
+- **Rooms**: At least 4-5 distinct rooms/areas (e.g. living room, kitchen, bedroom, bathroom, hallway/corridor).
+- **Furniture**: 3-5 items per room minimum. A living room should have: sofa, coffee table, TV stand, rug, bookshelf/lamp. A kitchen: counter, table, chairs, fridge.
+- **Materials**: At least 5 custom materials with distinct colors. Every surface should have an intentional material, not defaults.
+- **Lighting**: 1 point light per room + 1 directional sun. Each light should have appropriate color and intensity.
+- **Entities**: Player spawn + at least 1 NPC or interactive object.
+- **Outdoor**: A porch, patio, or entrance area adds visual interest.
+
+## Rules
+- Position everything in world space (meters). Double-check alignment math.
+- Keep text responses brief. After building, give a short summary of what was created.
+- Use query tools (list_nodes, get_node_details) when asked about the scene.`;
+}

--- a/apps/editor/src/lib/copilot/system-prompt.ts
+++ b/apps/editor/src/lib/copilot/system-prompt.ts
@@ -127,6 +127,14 @@ ${materialsList || "  (no materials in scene)"}
 ## Scene State
 ${sceneSummary}
 
+## Mesh Editing
+You have full mesh editing tools: extrude, bevel, subdivide, cut, merge, fill, arc, inflate, invert normals.
+- ALWAYS call get_mesh_topology first to get face/vertex/edge IDs before editing a mesh.
+- Mesh ops work on mesh nodes only. To edit a brush, first use convert_brush_to_mesh.
+- Common workflow: place_primitive → get_mesh_topology → extrude_mesh_faces / bevel_mesh_edges / subdivide_mesh_face.
+- Extrude amount is in meters (positive = outward along face normal).
+- Bevel width is in meters, steps controls smoothness (1=sharp chamfer, 3+=round).
+
 ## Visual Quality Tips
 - Use DISTINCT, contrasting colors for different materials — avoid all-grey scenes. Use warm browns for wood, whites for walls, greens/blues for accents.
 - Make rooms generously sized — at least 6m×5m for small rooms, 8m+ for main areas. Cramped rooms look bad.

--- a/apps/editor/src/lib/copilot/tool-declarations.ts
+++ b/apps/editor/src/lib/copilot/tool-declarations.ts
@@ -1,0 +1,430 @@
+import type { CopilotToolDeclaration } from "./types";
+
+export const COPILOT_TOOL_DECLARATIONS: CopilotToolDeclaration[] = [
+  // ── Placement ───────────────────────────────────────────────
+  {
+    name: "place_blockout_room",
+    description:
+      "Places a blockout room (enclosed box with walls, floor, ceiling). Open sides can be specified to create doorways or windows. Position is the center-bottom of the room.",
+    parameters: {
+      type: "object",
+      properties: {
+        x: { type: "number", description: "World X position of room center" },
+        y: { type: "number", description: "World Y position of room bottom (usually 0 for ground level)" },
+        z: { type: "number", description: "World Z position of room center" },
+        sizeX: { type: "number", description: "Room width in meters (X axis)" },
+        sizeY: { type: "number", description: "Room height in meters (Y axis)" },
+        sizeZ: { type: "number", description: "Room depth in meters (Z axis)" },
+        openSides: {
+          type: "array",
+          items: { type: "string", enum: ["north", "south", "east", "west", "top", "bottom"] },
+          description: "Sides to leave open (for doorways, windows, connections)"
+        },
+        materialId: { type: "string", description: "Material ID to apply. Use list_materials to see available IDs." },
+        name: { type: "string", description: "Display name for the room node" }
+      },
+      required: ["x", "y", "z", "sizeX", "sizeY", "sizeZ"]
+    }
+  },
+  {
+    name: "place_blockout_platform",
+    description:
+      "Places a flat blockout platform (floor slab, roof, shelf). Position is the center of the platform volume.",
+    parameters: {
+      type: "object",
+      properties: {
+        x: { type: "number", description: "World X position" },
+        y: { type: "number", description: "World Y position (center of slab thickness)" },
+        z: { type: "number", description: "World Z position" },
+        sizeX: { type: "number", description: "Platform width (X)" },
+        sizeY: { type: "number", description: "Platform thickness (Y), typically 0.25-0.5" },
+        sizeZ: { type: "number", description: "Platform depth (Z)" },
+        materialId: { type: "string", description: "Material ID" },
+        name: { type: "string", description: "Display name" }
+      },
+      required: ["x", "y", "z", "sizeX", "sizeY", "sizeZ"]
+    }
+  },
+  {
+    name: "place_blockout_stairs",
+    description:
+      "Places a parametric staircase with optional landings. Position is the center-bottom of the bottom landing. Returns topLandingCenter for chaining connections.",
+    parameters: {
+      type: "object",
+      properties: {
+        x: { type: "number", description: "World X position of stair base" },
+        y: { type: "number", description: "World Y position of stair base (bottom)" },
+        z: { type: "number", description: "World Z position of stair base" },
+        stepCount: { type: "number", description: "Number of steps" },
+        stepHeight: { type: "number", description: "Height of each step in meters (typical: 0.2)" },
+        treadDepth: { type: "number", description: "Depth of each step tread in meters (typical: 0.3)" },
+        width: { type: "number", description: "Stair width in meters" },
+        direction: {
+          type: "string",
+          enum: ["north", "south", "east", "west"],
+          description: "Direction the stairs ascend toward (default: north)"
+        },
+        materialId: { type: "string", description: "Material ID" },
+        name: { type: "string", description: "Display name" }
+      },
+      required: ["x", "y", "z", "stepCount", "stepHeight", "treadDepth", "width"]
+    }
+  },
+  {
+    name: "place_primitive",
+    description:
+      "Places a parametric primitive shape (cube, sphere, cylinder, cone). Can be a blockout brush or a physics prop.",
+    parameters: {
+      type: "object",
+      properties: {
+        x: { type: "number", description: "World X position" },
+        y: { type: "number", description: "World Y position" },
+        z: { type: "number", description: "World Z position" },
+        role: { type: "string", enum: ["brush", "prop"], description: "brush = static blockout, prop = physics object" },
+        shape: { type: "string", enum: ["cube", "sphere", "cylinder", "cone"], description: "Primitive shape" },
+        sizeX: { type: "number", description: "Size X (default: 2)" },
+        sizeY: { type: "number", description: "Size Y (default: 2, or 3 for cylinder/cone)" },
+        sizeZ: { type: "number", description: "Size Z (default: 2)" },
+        materialId: { type: "string", description: "Material ID to apply directly. Avoids needing a separate assign_material call." },
+        name: { type: "string", description: "Display name" }
+      },
+      required: ["x", "y", "z", "role", "shape"]
+    }
+  },
+  {
+    name: "place_brush",
+    description:
+      "Places a simple axis-aligned brush (CSG convex solid). Default is a 4x3x4 box. Use place_blockout_room or place_blockout_platform for level design; use this for custom-sized brushes.",
+    parameters: {
+      type: "object",
+      properties: {
+        x: { type: "number", description: "World X position" },
+        y: { type: "number", description: "World Y position" },
+        z: { type: "number", description: "World Z position" },
+        sizeX: { type: "number", description: "Brush width (default: 4)" },
+        sizeY: { type: "number", description: "Brush height (default: 3)" },
+        sizeZ: { type: "number", description: "Brush depth (default: 4)" },
+        name: { type: "string", description: "Display name" }
+      },
+      required: ["x", "y", "z"]
+    }
+  },
+  {
+    name: "place_light",
+    description: "Places a light in the scene. Types: point (local area), directional (sun), spot (focused cone), ambient (global fill), hemisphere (sky/ground).",
+    parameters: {
+      type: "object",
+      properties: {
+        x: { type: "number", description: "World X position" },
+        y: { type: "number", description: "World Y position" },
+        z: { type: "number", description: "World Z position" },
+        type: {
+          type: "string",
+          enum: ["point", "directional", "spot", "ambient", "hemisphere"],
+          description: "Light type"
+        },
+        color: { type: "string", description: "Hex color (e.g. '#ffffff')" },
+        intensity: { type: "number", description: "Light intensity" }
+      },
+      required: ["x", "y", "z", "type"]
+    }
+  },
+  {
+    name: "place_entity",
+    description: "Places a gameplay entity (spawn point, NPC, or interactive object).",
+    parameters: {
+      type: "object",
+      properties: {
+        x: { type: "number", description: "World X position" },
+        y: { type: "number", description: "World Y position" },
+        z: { type: "number", description: "World Z position" },
+        type: {
+          type: "string",
+          enum: ["player-spawn", "npc-spawn", "smart-object"],
+          description: "Entity type"
+        },
+        name: { type: "string", description: "Display name" }
+      },
+      required: ["x", "y", "z", "type"]
+    }
+  },
+
+  // ── Transform ───────────────────────────────────────────────
+  {
+    name: "translate_nodes",
+    description: "Moves nodes by a relative offset (delta). Does not set absolute position — adds delta to current position.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeIds: { type: "array", items: { type: "string" }, description: "Node IDs to move" },
+        dx: { type: "number", description: "X offset" },
+        dy: { type: "number", description: "Y offset" },
+        dz: { type: "number", description: "Z offset" }
+      },
+      required: ["nodeIds", "dx", "dy", "dz"]
+    }
+  },
+  {
+    name: "set_node_transform",
+    description: "Sets a node's absolute position, rotation, and scale.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Node ID" },
+        x: { type: "number", description: "Absolute X position" },
+        y: { type: "number", description: "Absolute Y position" },
+        z: { type: "number", description: "Absolute Z position" },
+        rotationX: { type: "number", description: "Rotation X in radians" },
+        rotationY: { type: "number", description: "Rotation Y in radians" },
+        rotationZ: { type: "number", description: "Rotation Z in radians" },
+        scaleX: { type: "number", description: "Scale X" },
+        scaleY: { type: "number", description: "Scale Y" },
+        scaleZ: { type: "number", description: "Scale Z" }
+      },
+      required: ["nodeId", "x", "y", "z"]
+    }
+  },
+  {
+    name: "duplicate_nodes",
+    description: "Duplicates nodes with a position offset. Returns the new node IDs.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeIds: { type: "array", items: { type: "string" }, description: "Node IDs to duplicate" },
+        offsetX: { type: "number", description: "X offset for duplicates" },
+        offsetY: { type: "number", description: "Y offset for duplicates" },
+        offsetZ: { type: "number", description: "Z offset for duplicates" }
+      },
+      required: ["nodeIds", "offsetX", "offsetY", "offsetZ"]
+    }
+  },
+  {
+    name: "mirror_nodes",
+    description: "Mirrors (flips) nodes across the specified axis.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeIds: { type: "array", items: { type: "string" }, description: "Node IDs to mirror" },
+        axis: { type: "string", enum: ["x", "y", "z"], description: "Axis to mirror across" }
+      },
+      required: ["nodeIds", "axis"]
+    }
+  },
+  {
+    name: "delete_nodes",
+    description: "Deletes nodes and/or entities by their IDs. Also removes all children.",
+    parameters: {
+      type: "object",
+      properties: {
+        ids: { type: "array", items: { type: "string" }, description: "Node or entity IDs to delete" }
+      },
+      required: ["ids"]
+    }
+  },
+
+  // ── Brush ───────────────────────────────────────────────────
+  {
+    name: "split_brush",
+    description: "Splits brush nodes at their midpoint along the specified axis. Returns the new node IDs.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeIds: { type: "array", items: { type: "string" }, description: "Brush node IDs to split" },
+        axis: { type: "string", enum: ["x", "y", "z"], description: "Axis to split along" }
+      },
+      required: ["nodeIds", "axis"]
+    }
+  },
+  {
+    name: "extrude_brush",
+    description: "Extrudes (grows) brush nodes along an axis by a given amount.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeIds: { type: "array", items: { type: "string" }, description: "Brush node IDs" },
+        axis: { type: "string", enum: ["x", "y", "z"], description: "Extrusion axis" },
+        amount: { type: "number", description: "Extrusion distance in meters" },
+        direction: { type: "string", enum: ["-1", "1"], description: "Extrusion direction: '-1' (negative) or '1' (positive)" }
+      },
+      required: ["nodeIds", "axis", "amount", "direction"]
+    }
+  },
+  {
+    name: "offset_brush_face",
+    description: "Moves a single face of a brush inward or outward.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Brush node ID" },
+        axis: { type: "string", enum: ["x", "y", "z"], description: "Face axis" },
+        side: { type: "string", enum: ["min", "max"], description: "Which face (min or max)" },
+        amount: { type: "number", description: "Offset amount (positive = outward)" }
+      },
+      required: ["nodeId", "axis", "side", "amount"]
+    }
+  },
+  {
+    name: "assign_material_to_brushes",
+    description: "Assigns a material to all faces of the specified brush nodes.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeIds: { type: "array", items: { type: "string" }, description: "Brush node IDs" },
+        materialId: { type: "string", description: "Material ID to assign" }
+      },
+      required: ["nodeIds", "materialId"]
+    }
+  },
+
+  // ── Materials ───────────────────────────────────────────────
+  {
+    name: "create_material",
+    description: "Creates or updates a material in the scene library. The ID is auto-generated as 'material:custom:<slug>' from the name (e.g. name 'Dark Wood' → id 'material:custom:dark-wood'). You can use this predictable ID immediately in assign_material calls.",
+    parameters: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Material display name" },
+        color: { type: "string", description: "Hex color (e.g. '#ff6633')" },
+        category: { type: "string", enum: ["flat", "blockout", "custom"], description: "Material category (default: custom)" },
+        metalness: { type: "number", description: "Metalness 0-1 (default: 0)" },
+        roughness: { type: "number", description: "Roughness 0-1 (default: 0.8)" }
+      },
+      required: ["name", "color"]
+    }
+  },
+  {
+    name: "assign_material",
+    description: "Assigns a material to nodes (all faces) or specific faces on nodes.",
+    parameters: {
+      type: "object",
+      properties: {
+        targets: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              nodeId: { type: "string", description: "Node ID" },
+              faceIds: { type: "array", items: { type: "string" }, description: "Optional face IDs (omit for all faces)" }
+            },
+            required: ["nodeId"]
+          },
+          description: "Nodes (and optional faces) to assign material to"
+        },
+        materialId: { type: "string", description: "Material ID to assign" }
+      },
+      required: ["targets", "materialId"]
+    }
+  },
+  {
+    name: "set_uv_scale",
+    description: "Sets UV texture tiling scale on nodes or specific faces.",
+    parameters: {
+      type: "object",
+      properties: {
+        targets: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              nodeId: { type: "string" },
+              faceIds: { type: "array", items: { type: "string" } }
+            },
+            required: ["nodeId"]
+          }
+        },
+        scaleX: { type: "number", description: "UV scale X" },
+        scaleY: { type: "number", description: "UV scale Y" }
+      },
+      required: ["targets", "scaleX", "scaleY"]
+    }
+  },
+
+  // ── Scene management ────────────────────────────────────────
+  {
+    name: "group_nodes",
+    description: "Groups nodes/entities under a new group node. Returns the group ID.",
+    parameters: {
+      type: "object",
+      properties: {
+        ids: { type: "array", items: { type: "string" }, description: "Node/entity IDs to group" }
+      },
+      required: ["ids"]
+    }
+  },
+  {
+    name: "select_nodes",
+    description: "Sets the editor selection to the given node/entity IDs.",
+    parameters: {
+      type: "object",
+      properties: {
+        ids: { type: "array", items: { type: "string" }, description: "IDs to select" }
+      },
+      required: ["ids"]
+    }
+  },
+  {
+    name: "clear_selection",
+    description: "Clears the current editor selection.",
+    parameters: { type: "object", properties: {} }
+  },
+  {
+    name: "undo",
+    description: "Undoes the last editor command.",
+    parameters: { type: "object", properties: {} }
+  },
+  {
+    name: "set_scene_settings",
+    description: "Updates scene settings (world physics, fog, ambient light, player config).",
+    parameters: {
+      type: "object",
+      properties: {
+        gravityX: { type: "number", description: "Gravity X (default: 0)" },
+        gravityY: { type: "number", description: "Gravity Y (default: -9.81)" },
+        gravityZ: { type: "number", description: "Gravity Z (default: 0)" },
+        physicsEnabled: { type: "boolean", description: "Enable physics simulation" },
+        ambientColor: { type: "string", description: "Ambient light hex color" },
+        ambientIntensity: { type: "number", description: "Ambient light intensity" },
+        fogColor: { type: "string", description: "Fog hex color" },
+        fogNear: { type: "number", description: "Fog near distance" },
+        fogFar: { type: "number", description: "Fog far distance" },
+        cameraMode: { type: "string", enum: ["fps", "third-person", "top-down"], description: "Player camera mode" },
+        playerHeight: { type: "number", description: "Player height in meters" },
+        movementSpeed: { type: "number", description: "Player movement speed" },
+        jumpHeight: { type: "number", description: "Player jump height" }
+      }
+    }
+  },
+
+  // ── Read-only queries ───────────────────────────────────────
+  {
+    name: "list_nodes",
+    description: "Lists all nodes in the scene with their ID, name, kind, and position.",
+    parameters: { type: "object", properties: {} }
+  },
+  {
+    name: "list_entities",
+    description: "Lists all entities in the scene with their ID, name, type, and position.",
+    parameters: { type: "object", properties: {} }
+  },
+  {
+    name: "list_materials",
+    description: "Lists all materials in the scene with their ID, name, color, and category.",
+    parameters: { type: "object", properties: {} }
+  },
+  {
+    name: "get_node_details",
+    description: "Gets full details of a specific node including its transform, kind, and data.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Node ID to inspect" }
+      },
+      required: ["nodeId"]
+    }
+  },
+  {
+    name: "get_scene_settings",
+    description: "Gets current scene settings (world physics, fog, ambient, player config).",
+    parameters: { type: "object", properties: {} }
+  }
+];

--- a/apps/editor/src/lib/copilot/tool-declarations.ts
+++ b/apps/editor/src/lib/copilot/tool-declarations.ts
@@ -426,5 +426,199 @@ export const COPILOT_TOOL_DECLARATIONS: CopilotToolDeclaration[] = [
     name: "get_scene_settings",
     description: "Gets current scene settings (world physics, fog, ambient, player config).",
     parameters: { type: "object", properties: {} }
+  },
+  {
+    name: "get_mesh_topology",
+    description: "Returns the face IDs, vertex IDs with positions, and edges for a mesh node. Use this before mesh editing operations to discover which faces/vertices/edges to target.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Mesh node ID to inspect" }
+      },
+      required: ["nodeId"]
+    }
+  },
+
+  // ── Mesh editing ────────────────────────────────────────────
+  {
+    name: "extrude_mesh_faces",
+    description: "Extrude one or more faces of a mesh node along their normal by an amount. Use get_mesh_topology first to find face IDs.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Mesh node ID" },
+        faceIds: { type: "array", items: { type: "string" }, description: "Face IDs to extrude" },
+        amount: { type: "number", description: "Extrusion distance in meters (positive = outward)" }
+      },
+      required: ["nodeId", "faceIds", "amount"]
+    }
+  },
+  {
+    name: "extrude_mesh_edge",
+    description: "Extrude a boundary edge of a mesh outward, creating a new quad face.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Mesh node ID" },
+        vertexId1: { type: "string", description: "First vertex ID of the edge" },
+        vertexId2: { type: "string", description: "Second vertex ID of the edge" },
+        amount: { type: "number", description: "Extrusion distance" }
+      },
+      required: ["nodeId", "vertexId1", "vertexId2", "amount"]
+    }
+  },
+  {
+    name: "bevel_mesh_edges",
+    description: "Bevel (chamfer/round) edges of a mesh. Creates smooth transitions at sharp edges.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Mesh node ID" },
+        edges: { type: "array", items: { type: "array", items: { type: "string" } }, description: "Edges as [[vertexId1, vertexId2], ...] pairs" },
+        width: { type: "number", description: "Bevel width in meters" },
+        steps: { type: "number", description: "Number of bevel segments (1=flat chamfer, 3+=smooth round)" },
+        profile: { type: "string", enum: ["flat", "round"], description: "Bevel profile shape (default: flat)" }
+      },
+      required: ["nodeId", "edges", "width", "steps"]
+    }
+  },
+  {
+    name: "subdivide_mesh_face",
+    description: "Subdivide a mesh face into smaller faces. Quad faces get a grid pattern, others get radial.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Mesh node ID" },
+        faceId: { type: "string", description: "Face ID to subdivide" },
+        cuts: { type: "number", description: "Number of cuts (1=2x2 for quads, 2=3x3, etc.)" }
+      },
+      required: ["nodeId", "faceId", "cuts"]
+    }
+  },
+  {
+    name: "cut_mesh_face",
+    description: "Cut a mesh face with a line passing through a point, splitting it into two faces.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Mesh node ID" },
+        faceId: { type: "string", description: "Face ID to cut" },
+        pointX: { type: "number", description: "X coordinate of cut point on the face" },
+        pointY: { type: "number", description: "Y coordinate" },
+        pointZ: { type: "number", description: "Z coordinate" },
+        snapSize: { type: "number", description: "Snap resolution (default: 1)" }
+      },
+      required: ["nodeId", "faceId", "pointX", "pointY", "pointZ"]
+    }
+  },
+  {
+    name: "delete_mesh_faces",
+    description: "Delete faces from a mesh, leaving holes.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Mesh node ID" },
+        faceIds: { type: "array", items: { type: "string" }, description: "Face IDs to delete" }
+      },
+      required: ["nodeId", "faceIds"]
+    }
+  },
+  {
+    name: "merge_mesh_faces",
+    description: "Merge adjacent coplanar faces into a single face.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Mesh node ID" },
+        faceIds: { type: "array", items: { type: "string" }, description: "Face IDs to merge (must be coplanar and adjacent)" }
+      },
+      required: ["nodeId", "faceIds"]
+    }
+  },
+  {
+    name: "merge_mesh_vertices",
+    description: "Merge multiple vertices to their average position.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Mesh node ID" },
+        vertexIds: { type: "array", items: { type: "string" }, description: "Vertex IDs to merge" }
+      },
+      required: ["nodeId", "vertexIds"]
+    }
+  },
+  {
+    name: "fill_mesh_face",
+    description: "Create a new face from a loop of boundary vertices, filling a hole in the mesh.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Mesh node ID" },
+        vertexIds: { type: "array", items: { type: "string" }, description: "Vertex IDs forming the boundary loop (>=3, must be boundary vertices)" }
+      },
+      required: ["nodeId", "vertexIds"]
+    }
+  },
+  {
+    name: "invert_mesh_normals",
+    description: "Flip face normals (winding order) on selected or all faces of a mesh.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Mesh node ID" },
+        faceIds: { type: "array", items: { type: "string" }, description: "Face IDs to invert (omit for all faces)" }
+      },
+      required: ["nodeId"]
+    }
+  },
+  {
+    name: "arc_mesh_edges",
+    description: "Curve straight edges into arcs by inserting interpolated vertices.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Mesh node ID" },
+        edges: { type: "array", items: { type: "array", items: { type: "string" } }, description: "Edges as [[vertexId1, vertexId2], ...] pairs" },
+        offset: { type: "number", description: "Arc height/offset in meters" },
+        segments: { type: "number", description: "Number of arc segments (minimum 2)" }
+      },
+      required: ["nodeId", "edges", "offset", "segments"]
+    }
+  },
+  {
+    name: "inflate_mesh",
+    description: "Move all vertices of mesh nodes along their averaged normals (inflate/deflate).",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeIds: { type: "array", items: { type: "string" }, description: "Mesh node IDs" },
+        factor: { type: "number", description: "Inflate factor (positive = outward, negative = inward)" }
+      },
+      required: ["nodeIds", "factor"]
+    }
+  },
+  {
+    name: "convert_brush_to_mesh",
+    description: "Convert a brush (CSG solid) node into an editable mesh node, enabling face/edge/vertex editing.",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Brush node ID to convert" }
+      },
+      required: ["nodeId"]
+    }
+  },
+  {
+    name: "split_brush_at_coordinate",
+    description: "Split a brush node at an exact world coordinate along an axis (more precise than split_brush which only splits at the midpoint).",
+    parameters: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "Brush node ID" },
+        axis: { type: "string", enum: ["x", "y", "z"], description: "Axis to split along" },
+        coordinate: { type: "number", description: "World coordinate to split at" }
+      },
+      required: ["nodeId", "axis", "coordinate"]
+    }
   }
 ];

--- a/apps/editor/src/lib/copilot/tool-executor.ts
+++ b/apps/editor/src/lib/copilot/tool-executor.ts
@@ -6,6 +6,7 @@ import {
   createDuplicateNodesCommand,
   createExtrudeBrushNodesCommand,
   createGroupSelectionCommand,
+  createMeshInflateCommand,
   createMirrorNodesCommand,
   createOffsetBrushFaceCommand,
   createPlaceBlockoutPlatformCommand,
@@ -15,16 +16,33 @@ import {
   createPlaceEntityCommand,
   createPlaceLightNodeCommand,
   createPlacePrimitiveNodeCommand,
+  createReplaceNodesCommand,
+  createSetMeshDataCommand,
   createSetNodeTransformCommand,
   createSetSceneSettingsCommand,
   createSetUvScaleCommand,
+  createSplitBrushNodeAtCoordinateCommand,
   createSplitBrushNodesCommand,
   createTranslateNodesCommand,
   createUpsertMaterialCommand
 } from "@web-hammer/editor-core";
-import { createAxisAlignedBrushFromBounds } from "@web-hammer/geometry-kernel";
-import { makeTransform, vec3 } from "@web-hammer/shared";
-import type { Material, SceneSettings } from "@web-hammer/shared";
+import {
+  arcEditableMeshEdges,
+  bevelEditableMeshEdges,
+  convertBrushToEditableMesh,
+  createAxisAlignedBrushFromBounds,
+  cutEditableMeshFace,
+  deleteEditableMeshFaces,
+  extrudeEditableMeshEdge,
+  extrudeEditableMeshFaces,
+  fillEditableMeshFaceFromVertices,
+  invertEditableMeshNormals,
+  mergeEditableMeshFaces,
+  mergeEditableMeshVertices,
+  subdivideEditableMeshFace
+} from "@web-hammer/geometry-kernel";
+import { isBrushNode, isMeshNode, makeTransform, vec3 } from "@web-hammer/shared";
+import type { EditableMesh, Material, SceneSettings } from "@web-hammer/shared";
 import {
   createDefaultEntity,
   createDefaultLightData,
@@ -413,7 +431,197 @@ function executeToolInner(editor: EditorCore, name: string, args: Args): string 
       return JSON.stringify(scene.settings);
     }
 
+    // ── Mesh topology query ─────────────────────────────────
+    case "get_mesh_topology": {
+      const node = scene.getNode(str(args, "nodeId"));
+
+      if (!node || !isMeshNode(node)) {
+        return fail("Node is not a mesh");
+      }
+
+      const mesh = node.data;
+      const faces = mesh.faces.map((f) => {
+        const vIds: string[] = [];
+        let he = mesh.halfEdges.find((h) => h.id === f.halfEdge);
+
+        if (he) {
+          const startId = he.id;
+          do {
+            vIds.push(he!.vertex);
+            he = mesh.halfEdges.find((h) => h.id === he!.next);
+          } while (he && he.id !== startId);
+        }
+
+        return { id: f.id, vertexIds: vIds, materialId: f.materialId };
+      });
+
+      const vertices = mesh.vertices.map((v) => ({
+        id: v.id,
+        position: v.position
+      }));
+
+      const edgeSet = new Set<string>();
+      const edges: [string, string][] = [];
+
+      for (const he of mesh.halfEdges) {
+        const twin = he.twin ? mesh.halfEdges.find((h) => h.id === he.twin) : undefined;
+
+        if (twin) {
+          const key = [he.vertex, twin.vertex].sort().join(":");
+
+          if (!edgeSet.has(key)) {
+            edgeSet.add(key);
+            edges.push([he.vertex, twin.vertex]);
+          }
+        }
+      }
+
+      return JSON.stringify({ faces, vertices, edges });
+    }
+
+    // ── Mesh editing ──────────────────────────────────────────
+    case "extrude_mesh_faces":
+      return executeMeshOp(editor, str(args, "nodeId"), (mesh) =>
+        extrudeEditableMeshFaces(mesh, strArray(args, "faceIds"), num(args, "amount")),
+        "Extrude faces"
+      );
+
+    case "extrude_mesh_edge":
+      return executeMeshOp(editor, str(args, "nodeId"), (mesh) =>
+        extrudeEditableMeshEdge(mesh, [str(args, "vertexId1"), str(args, "vertexId2")], num(args, "amount")),
+        "Extrude edge"
+      );
+
+    case "bevel_mesh_edges": {
+      const edges = (args.edges as string[][] ?? []).map((e) => [e[0], e[1]] as [string, string]);
+      return executeMeshOp(editor, str(args, "nodeId"), (mesh) =>
+        bevelEditableMeshEdges(mesh, edges, num(args, "width"), num(args, "steps", 1),
+          (str(args, "profile") || "flat") as "flat" | "round"),
+        "Bevel edges"
+      );
+    }
+
+    case "subdivide_mesh_face":
+      return executeMeshOp(editor, str(args, "nodeId"), (mesh) =>
+        subdivideEditableMeshFace(mesh, str(args, "faceId"), num(args, "cuts", 1)),
+        "Subdivide face"
+      );
+
+    case "cut_mesh_face":
+      return executeMeshOp(editor, str(args, "nodeId"), (mesh) =>
+        cutEditableMeshFace(mesh, str(args, "faceId"),
+          vec3(num(args, "pointX"), num(args, "pointY"), num(args, "pointZ")),
+          num(args, "snapSize", 1)),
+        "Cut face"
+      );
+
+    case "delete_mesh_faces":
+      return executeMeshOp(editor, str(args, "nodeId"), (mesh) =>
+        deleteEditableMeshFaces(mesh, strArray(args, "faceIds")),
+        "Delete faces"
+      );
+
+    case "merge_mesh_faces":
+      return executeMeshOp(editor, str(args, "nodeId"), (mesh) =>
+        mergeEditableMeshFaces(mesh, strArray(args, "faceIds")),
+        "Merge faces"
+      );
+
+    case "merge_mesh_vertices":
+      return executeMeshOp(editor, str(args, "nodeId"), (mesh) =>
+        mergeEditableMeshVertices(mesh, strArray(args, "vertexIds")),
+        "Merge vertices"
+      );
+
+    case "fill_mesh_face":
+      return executeMeshOp(editor, str(args, "nodeId"), (mesh) =>
+        fillEditableMeshFaceFromVertices(mesh, strArray(args, "vertexIds")),
+        "Fill face"
+      );
+
+    case "invert_mesh_normals":
+      return executeMeshOp(editor, str(args, "nodeId"), (mesh) =>
+        invertEditableMeshNormals(mesh, strArray(args, "faceIds").length > 0 ? strArray(args, "faceIds") : undefined),
+        "Invert normals"
+      );
+
+    case "arc_mesh_edges": {
+      const arcEdges = (args.edges as string[][] ?? []).map((e) => [e[0], e[1]] as [string, string]);
+      return executeMeshOp(editor, str(args, "nodeId"), (mesh) =>
+        arcEditableMeshEdges(mesh, arcEdges, num(args, "offset"), num(args, "segments", 2)),
+        "Arc edges"
+      );
+    }
+
+    case "inflate_mesh": {
+      const command = createMeshInflateCommand(scene, strArray(args, "nodeIds"), num(args, "factor"));
+      editor.execute(command);
+      return ok({});
+    }
+
+    case "convert_brush_to_mesh": {
+      const nodeId = str(args, "nodeId");
+      const node = scene.getNode(nodeId);
+
+      if (!node || !isBrushNode(node)) {
+        return fail("Node is not a brush");
+      }
+
+      const meshData = convertBrushToEditableMesh(node.data);
+
+      if (!meshData) {
+        return fail("Failed to convert brush to mesh");
+      }
+
+      const meshNode = {
+        ...structuredClone(node),
+        kind: "mesh" as const,
+        data: meshData
+      };
+
+      const command = createReplaceNodesCommand(scene, [meshNode], "convert brush to mesh");
+      editor.execute(command);
+      return ok({ nodeId });
+    }
+
+    case "split_brush_at_coordinate": {
+      const { command, splitIds } = createSplitBrushNodeAtCoordinateCommand(
+        scene,
+        str(args, "nodeId"),
+        str(args, "axis", "x") as "x" | "y" | "z",
+        num(args, "coordinate")
+      );
+      editor.execute(command);
+      return ok({ splitIds });
+    }
+
     default:
       return fail(`Unknown tool: ${name}`);
   }
+}
+
+function executeMeshOp(
+  editor: EditorCore,
+  nodeId: string,
+  op: (mesh: EditableMesh) => EditableMesh | undefined,
+  label: string
+): string {
+  const node = editor.scene.getNode(nodeId);
+
+  if (!node || !isMeshNode(node)) {
+    return fail("Node is not a mesh");
+  }
+
+  const result = op(node.data);
+
+  if (!result) {
+    return fail(`${label} failed`);
+  }
+
+  // Preserve physics and role metadata from the original mesh
+  result.physics = node.data.physics;
+  result.role = node.data.role;
+
+  editor.execute(createSetMeshDataCommand(editor.scene, nodeId, result, node.data));
+  return ok({});
 }

--- a/apps/editor/src/lib/copilot/tool-executor.ts
+++ b/apps/editor/src/lib/copilot/tool-executor.ts
@@ -154,6 +154,7 @@ function executeToolInner(editor: EditorCore, name: string, args: Args): string 
     case "place_light": {
       const lightType = str(args, "type", "point") as "ambient" | "directional" | "hemisphere" | "point" | "spot";
       const data = createDefaultLightData(lightType);
+      data.castShadow = false;
 
       if (args.color && typeof args.color === "string") {
         data.color = args.color;

--- a/apps/editor/src/lib/copilot/tool-executor.ts
+++ b/apps/editor/src/lib/copilot/tool-executor.ts
@@ -1,0 +1,418 @@
+import type { EditorCore } from "@web-hammer/editor-core";
+import {
+  createAssignMaterialCommand,
+  createAssignMaterialToBrushesCommand,
+  createDeleteSelectionCommand,
+  createDuplicateNodesCommand,
+  createExtrudeBrushNodesCommand,
+  createGroupSelectionCommand,
+  createMirrorNodesCommand,
+  createOffsetBrushFaceCommand,
+  createPlaceBlockoutPlatformCommand,
+  createPlaceBlockoutRoomCommand,
+  createPlaceBlockoutStairCommand,
+  createPlaceBrushNodeCommand,
+  createPlaceEntityCommand,
+  createPlaceLightNodeCommand,
+  createPlacePrimitiveNodeCommand,
+  createSetNodeTransformCommand,
+  createSetSceneSettingsCommand,
+  createSetUvScaleCommand,
+  createSplitBrushNodesCommand,
+  createTranslateNodesCommand,
+  createUpsertMaterialCommand
+} from "@web-hammer/editor-core";
+import { createAxisAlignedBrushFromBounds } from "@web-hammer/geometry-kernel";
+import { makeTransform, vec3 } from "@web-hammer/shared";
+import type { Material, SceneSettings } from "@web-hammer/shared";
+import {
+  createDefaultEntity,
+  createDefaultLightData,
+  createLightNodeLabel,
+  createPrimitiveNodeData,
+  createPrimitiveNodeLabel
+} from "@/lib/authoring";
+import type { CopilotToolCall, CopilotToolResult } from "./types";
+
+type Args = Record<string, unknown>;
+
+function num(args: Args, key: string, fallback = 0): number {
+  const v = args[key];
+  return typeof v === "number" ? v : fallback;
+}
+
+function str(args: Args, key: string, fallback = ""): string {
+  const v = args[key];
+  return typeof v === "string" ? v : fallback;
+}
+
+function strArray(args: Args, key: string): string[] {
+  const v = args[key];
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+}
+
+function ok(data: Record<string, unknown>): string {
+  return JSON.stringify({ success: true, ...data });
+}
+
+function fail(error: string): string {
+  return JSON.stringify({ success: false, error });
+}
+
+export function executeTool(editor: EditorCore, toolCall: CopilotToolCall): CopilotToolResult {
+  const { name, args } = toolCall;
+
+  try {
+    const result = executeToolInner(editor, name, args);
+    return { callId: toolCall.id, name, result };
+  } catch (error) {
+    return {
+      callId: toolCall.id,
+      name,
+      result: fail(error instanceof Error ? error.message : "Unknown error")
+    };
+  }
+}
+
+function executeToolInner(editor: EditorCore, name: string, args: Args): string {
+  const scene = editor.scene;
+
+  switch (name) {
+    // ── Placement ─────────────────────────────────────────────
+    case "place_blockout_room": {
+      const { command, groupId, nodeIds } = createPlaceBlockoutRoomCommand(scene, {
+        position: vec3(num(args, "x"), num(args, "y"), num(args, "z")),
+        size: vec3(num(args, "sizeX", 10), num(args, "sizeY", 4), num(args, "sizeZ", 10)),
+        openSides: strArray(args, "openSides") as Array<"bottom" | "east" | "north" | "south" | "top" | "west">,
+        materialId: str(args, "materialId") || undefined,
+        name: str(args, "name") || undefined
+      });
+      editor.execute(command);
+      return ok({ groupId, nodeIds });
+    }
+
+    case "place_blockout_platform": {
+      const { command, nodeId } = createPlaceBlockoutPlatformCommand(scene, {
+        position: vec3(num(args, "x"), num(args, "y"), num(args, "z")),
+        size: vec3(num(args, "sizeX", 8), num(args, "sizeY", 0.5), num(args, "sizeZ", 8)),
+        materialId: str(args, "materialId") || undefined,
+        name: str(args, "name") || undefined
+      });
+      editor.execute(command);
+      return ok({ nodeId });
+    }
+
+    case "place_blockout_stairs": {
+      const { command, groupId, nodeIds, topLandingCenter } = createPlaceBlockoutStairCommand(scene, {
+        position: vec3(num(args, "x"), num(args, "y"), num(args, "z")),
+        stepCount: num(args, "stepCount", 10),
+        stepHeight: num(args, "stepHeight", 0.2),
+        treadDepth: num(args, "treadDepth", 0.3),
+        width: num(args, "width", 2),
+        direction: (str(args, "direction") || "north") as "east" | "north" | "south" | "west",
+        materialId: str(args, "materialId") || undefined,
+        name: str(args, "name") || undefined
+      });
+      editor.execute(command);
+      return ok({ groupId, nodeIds, topLandingCenter });
+    }
+
+    case "place_primitive": {
+      const role = str(args, "role", "brush") as "brush" | "prop";
+      const shape = str(args, "shape", "cube") as "cone" | "cube" | "cylinder" | "sphere";
+      const size = vec3(num(args, "sizeX", 2), num(args, "sizeY", shape === "cylinder" || shape === "cone" ? 3 : 2), num(args, "sizeZ", 2));
+      const data = createPrimitiveNodeData(role, shape, size);
+      const matId = str(args, "materialId");
+      if (matId) {
+        data.materialId = matId;
+      }
+      const transform = makeTransform(vec3(num(args, "x"), num(args, "y"), num(args, "z")));
+      const label = str(args, "name") || createPrimitiveNodeLabel(role, shape);
+      const { command, nodeId } = createPlacePrimitiveNodeCommand(scene, transform, { data, name: label });
+      editor.execute(command);
+      return ok({ nodeId });
+    }
+
+    case "place_brush": {
+      const halfX = num(args, "sizeX", 4) * 0.5;
+      const halfY = num(args, "sizeY", 3) * 0.5;
+      const halfZ = num(args, "sizeZ", 4) * 0.5;
+      const transform = makeTransform(vec3(num(args, "x"), num(args, "y"), num(args, "z")));
+      const brushData = createAxisAlignedBrushFromBounds({
+        x: { min: -halfX, max: halfX },
+        y: { min: -halfY, max: halfY },
+        z: { min: -halfZ, max: halfZ }
+      });
+      const { command, nodeId } = createPlaceBrushNodeCommand(scene, transform, {
+        data: brushData,
+        name: str(args, "name") || "Brush"
+      });
+      editor.execute(command);
+      return ok({ nodeId });
+    }
+
+    case "place_light": {
+      const lightType = str(args, "type", "point") as "ambient" | "directional" | "hemisphere" | "point" | "spot";
+      const data = createDefaultLightData(lightType);
+
+      if (args.color && typeof args.color === "string") {
+        data.color = args.color;
+      }
+
+      if (typeof args.intensity === "number") {
+        data.intensity = args.intensity;
+      }
+
+      const transform = makeTransform(vec3(num(args, "x"), num(args, "y"), num(args, "z")));
+      const label = str(args, "name") || createLightNodeLabel(lightType);
+      const { command, nodeId } = createPlaceLightNodeCommand(scene, transform, { data, name: label });
+      editor.execute(command);
+      return ok({ nodeId });
+    }
+
+    case "place_entity": {
+      const entityType = str(args, "type", "player-spawn") as "npc-spawn" | "player-spawn" | "smart-object";
+      const entityCount = Array.from(scene.entities.values()).filter((e) => e.type === entityType).length;
+      const entity = createDefaultEntity(entityType, vec3(num(args, "x"), num(args, "y"), num(args, "z")), entityCount);
+
+      if (str(args, "name")) {
+        entity.name = str(args, "name");
+      }
+
+      const command = createPlaceEntityCommand(entity);
+      editor.execute(command);
+      return ok({ entityId: entity.id });
+    }
+
+    // ── Transform ─────────────────────────────────────────────
+    case "translate_nodes": {
+      const nodeIds = strArray(args, "nodeIds");
+      const delta = vec3(num(args, "dx"), num(args, "dy"), num(args, "dz"));
+      const command = createTranslateNodesCommand(nodeIds, delta);
+      editor.execute(command);
+      return ok({});
+    }
+
+    case "set_node_transform": {
+      const nodeId = str(args, "nodeId");
+      const transform = makeTransform(vec3(num(args, "x"), num(args, "y"), num(args, "z")));
+
+      if (typeof args.rotationX === "number") transform.rotation.x = args.rotationX as number;
+      if (typeof args.rotationY === "number") transform.rotation.y = args.rotationY as number;
+      if (typeof args.rotationZ === "number") transform.rotation.z = args.rotationZ as number;
+      if (typeof args.scaleX === "number") transform.scale.x = args.scaleX as number;
+      if (typeof args.scaleY === "number") transform.scale.y = args.scaleY as number;
+      if (typeof args.scaleZ === "number") transform.scale.z = args.scaleZ as number;
+
+      const command = createSetNodeTransformCommand(scene, nodeId, transform);
+      editor.execute(command);
+      return ok({});
+    }
+
+    case "duplicate_nodes": {
+      const nodeIds = strArray(args, "nodeIds");
+      const offset = vec3(num(args, "offsetX"), num(args, "offsetY"), num(args, "offsetZ"));
+      const { command, duplicateIds } = createDuplicateNodesCommand(scene, nodeIds, offset);
+      editor.execute(command);
+      return ok({ duplicateIds });
+    }
+
+    case "mirror_nodes": {
+      const command = createMirrorNodesCommand(strArray(args, "nodeIds"), str(args, "axis", "x") as "x" | "y" | "z");
+      editor.execute(command);
+      return ok({});
+    }
+
+    case "delete_nodes": {
+      const command = createDeleteSelectionCommand(scene, strArray(args, "ids"));
+      editor.execute(command);
+      return ok({});
+    }
+
+    // ── Brush ─────────────────────────────────────────────────
+    case "split_brush": {
+      const { command, splitIds } = createSplitBrushNodesCommand(
+        scene,
+        strArray(args, "nodeIds"),
+        str(args, "axis", "x") as "x" | "y" | "z"
+      );
+      editor.execute(command);
+      return ok({ splitIds });
+    }
+
+    case "extrude_brush": {
+      const command = createExtrudeBrushNodesCommand(
+        scene,
+        strArray(args, "nodeIds"),
+        str(args, "axis", "y") as "x" | "y" | "z",
+        num(args, "amount", 1),
+        (String(args.direction ?? "1") === "-1" ? -1 : 1) as -1 | 1
+      );
+      editor.execute(command);
+      return ok({});
+    }
+
+    case "offset_brush_face": {
+      const command = createOffsetBrushFaceCommand(
+        scene,
+        str(args, "nodeId"),
+        str(args, "axis", "y") as "x" | "y" | "z",
+        str(args, "side", "max") as "max" | "min",
+        num(args, "amount")
+      );
+      editor.execute(command);
+      return ok({});
+    }
+
+    case "assign_material_to_brushes": {
+      const command = createAssignMaterialToBrushesCommand(scene, strArray(args, "nodeIds"), str(args, "materialId"));
+      editor.execute(command);
+      return ok({});
+    }
+
+    // ── Materials ─────────────────────────────────────────────
+    case "create_material": {
+      const materialName = str(args, "name", "Custom Material");
+      const slug = materialName.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+      const id = str(args, "id") || `material:custom:${slug}`;
+      const material: Material = {
+        id,
+        name: materialName,
+        color: str(args, "color", "#808080"),
+        category: (str(args, "category") || "custom") as "blockout" | "custom" | "flat",
+        metalness: num(args, "metalness", 0),
+        roughness: num(args, "roughness", 0.8)
+      };
+      const command = createUpsertMaterialCommand(scene, material);
+      editor.execute(command);
+      return ok({ materialId: id });
+    }
+
+    case "assign_material": {
+      const targets = (args.targets as Array<{ nodeId: string; faceIds?: string[] }>) ?? [];
+      const materialId = str(args, "materialId");
+      const command = createAssignMaterialCommand(scene, targets, materialId);
+      editor.execute(command);
+      return ok({});
+    }
+
+    case "set_uv_scale": {
+      const targets = (args.targets as Array<{ nodeId: string; faceIds?: string[] }>) ?? [];
+      const uvScale = { x: num(args, "scaleX", 1), y: num(args, "scaleY", 1) };
+      const command = createSetUvScaleCommand(scene, targets, uvScale);
+      editor.execute(command);
+      return ok({});
+    }
+
+    // ── Scene management ──────────────────────────────────────
+    case "group_nodes": {
+      const result = createGroupSelectionCommand(scene, strArray(args, "ids"));
+
+      if (!result) {
+        return fail("No valid nodes to group");
+      }
+
+      editor.execute(result.command);
+      return ok({ groupId: result.groupId });
+    }
+
+    case "select_nodes": {
+      editor.select(strArray(args, "ids"), "object");
+      return ok({});
+    }
+
+    case "clear_selection": {
+      editor.clearSelection();
+      return ok({});
+    }
+
+    case "undo": {
+      editor.undo();
+      return ok({});
+    }
+
+    case "set_scene_settings": {
+      const current = scene.settings;
+      const next: SceneSettings = structuredClone(current);
+
+      if (typeof args.gravityX === "number" || typeof args.gravityY === "number" || typeof args.gravityZ === "number") {
+        next.world.gravity = vec3(
+          num(args, "gravityX", current.world.gravity.x),
+          num(args, "gravityY", current.world.gravity.y),
+          num(args, "gravityZ", current.world.gravity.z)
+        );
+      }
+
+      if (typeof args.physicsEnabled === "boolean") next.world.physicsEnabled = args.physicsEnabled;
+      if (typeof args.ambientColor === "string") next.world.ambientColor = args.ambientColor as string;
+      if (typeof args.ambientIntensity === "number") next.world.ambientIntensity = args.ambientIntensity;
+      if (typeof args.fogColor === "string") next.world.fogColor = args.fogColor as string;
+      if (typeof args.fogNear === "number") next.world.fogNear = args.fogNear;
+      if (typeof args.fogFar === "number") next.world.fogFar = args.fogFar;
+      if (typeof args.cameraMode === "string") next.player.cameraMode = args.cameraMode as "fps" | "third-person" | "top-down";
+      if (typeof args.playerHeight === "number") next.player.height = args.playerHeight;
+      if (typeof args.movementSpeed === "number") next.player.movementSpeed = args.movementSpeed;
+      if (typeof args.jumpHeight === "number") next.player.jumpHeight = args.jumpHeight;
+
+      const command = createSetSceneSettingsCommand(scene, next);
+      editor.execute(command);
+      return ok({});
+    }
+
+    // ── Read-only queries ─────────────────────────────────────
+    case "list_nodes": {
+      const nodes = Array.from(scene.nodes.values()).map((n) => ({
+        id: n.id,
+        name: n.name,
+        kind: n.kind,
+        position: n.transform.position,
+        tags: n.tags
+      }));
+      return JSON.stringify({ nodes });
+    }
+
+    case "list_entities": {
+      const entities = Array.from(scene.entities.values()).map((e) => ({
+        id: e.id,
+        name: e.name,
+        type: e.type,
+        position: e.transform.position
+      }));
+      return JSON.stringify({ entities });
+    }
+
+    case "list_materials": {
+      const materials = Array.from(scene.materials.values()).map((m) => ({
+        id: m.id,
+        name: m.name,
+        color: m.color,
+        category: m.category
+      }));
+      return JSON.stringify({ materials });
+    }
+
+    case "get_node_details": {
+      const node = scene.getNode(str(args, "nodeId"));
+
+      if (!node) {
+        return fail("Node not found");
+      }
+
+      return JSON.stringify({
+        id: node.id,
+        name: node.name,
+        kind: node.kind,
+        transform: node.transform,
+        tags: node.tags,
+        metadata: node.metadata
+      });
+    }
+
+    case "get_scene_settings": {
+      return JSON.stringify(scene.settings);
+    }
+
+    default:
+      return fail(`Unknown tool: ${name}`);
+  }
+}

--- a/apps/editor/src/lib/copilot/types.ts
+++ b/apps/editor/src/lib/copilot/types.ts
@@ -1,0 +1,73 @@
+export type CopilotModelId = "gemini-3-flash-preview" | "gemini-3.1-pro-preview";
+
+export type CopilotSettings = {
+  apiKey: string;
+  model: CopilotModelId;
+  temperature: number;
+};
+
+export type CopilotMessage = {
+  id: string;
+  role: "user" | "assistant" | "tool";
+  content: string;
+  toolCalls?: CopilotToolCall[];
+  toolResults?: CopilotToolResult[];
+  /** Raw provider response parts — preserved verbatim for thought signatures */
+  rawParts?: unknown[];
+  timestamp: number;
+};
+
+export type CopilotToolCall = {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+};
+
+export type CopilotToolResult = {
+  callId: string;
+  name: string;
+  result: string;
+};
+
+export type CopilotToolDeclaration = {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+};
+
+export type CopilotProviderConfig = {
+  apiKey: string;
+  model: string;
+  temperature: number;
+};
+
+export type CopilotResponse = {
+  text: string;
+  toolCalls: CopilotToolCall[];
+  /** Raw parts from the model response, preserved for thought signatures */
+  rawParts: unknown[];
+};
+
+export type CopilotSessionStatus =
+  | "idle"
+  | "thinking"
+  | "executing"
+  | "error"
+  | "aborted";
+
+export type CopilotSession = {
+  messages: CopilotMessage[];
+  status: CopilotSessionStatus;
+  error?: string;
+  iterationCount: number;
+};
+
+export type CopilotProvider = {
+  generateContent(
+    messages: CopilotMessage[],
+    tools: CopilotToolDeclaration[],
+    systemPrompt: string,
+    config: CopilotProviderConfig,
+    signal?: AbortSignal
+  ): Promise<CopilotResponse>;
+};

--- a/apps/editor/src/lib/copilot/types.ts
+++ b/apps/editor/src/lib/copilot/types.ts
@@ -1,10 +1,20 @@
-export type CopilotModelId = "gemini-3-flash-preview" | "gemini-3.1-pro-preview";
+// ── Provider and model IDs ────────────────────────────────────
+
+export type CopilotProviderId = "gemini" | "codex";
+export type GeminiModelId = "gemini-3-flash-preview" | "gemini-3.1-pro-preview";
+export type CodexModelId = "gpt-5.4" | "gpt-5.3-codex" | "gpt-5.1-codex-max" | "gpt-4.1" | "gpt-4.1-mini" | "codex-mini-latest" | "o3" | "o4-mini";
+export type CopilotModelId = GeminiModelId | CodexModelId;
+
+// ── Settings ──────────────────────────────────────────────────
 
 export type CopilotSettings = {
-  apiKey: string;
-  model: CopilotModelId;
+  provider: CopilotProviderId;
+  gemini: { apiKey: string; model: GeminiModelId };
+  codex: { model: CodexModelId };
   temperature: number;
 };
+
+// ── Messages ──────────────────────────────────────────────────
 
 export type CopilotMessage = {
   id: string;
@@ -62,6 +72,9 @@ export type CopilotSession = {
   iterationCount: number;
 };
 
+// ── Provider interfaces ───────────────────────────────────────
+
+/** Request-response provider (Gemini) — used with the agentic loop */
 export type CopilotProvider = {
   generateContent(
     messages: CopilotMessage[],
@@ -71,3 +84,22 @@ export type CopilotProvider = {
     signal?: AbortSignal
   ): Promise<CopilotResponse>;
 };
+
+/** Session-based provider (Codex) — manages its own tool-calling loop */
+export type SessionBasedCopilotProvider = {
+  runSession(config: {
+    messages: CopilotMessage[];
+    userPrompt: string;
+    tools: CopilotToolDeclaration[];
+    systemPrompt: string;
+    providerConfig: CopilotProviderConfig;
+    executeTool: (call: CopilotToolCall) => CopilotToolResult;
+    onUpdate: (session: CopilotSession) => void;
+    signal?: AbortSignal;
+  }): Promise<CopilotSession>;
+};
+
+/** Discriminated union for provider factory */
+export type AnyCopilotProvider =
+  | { kind: "request-response"; provider: CopilotProvider }
+  | { kind: "session-based"; provider: SessionBasedCopilotProvider };

--- a/apps/editor/src/state/ui-store.ts
+++ b/apps/editor/src/state/ui-store.ts
@@ -7,7 +7,8 @@ export type RightPanelId = "events" | "hooks" | "inspector" | "materials" | "pla
 
 type UiStore = {
   activeViewportId: ViewportPaneId;
-  rightPanel: RightPanelId;
+  copilotPanelOpen: boolean;
+  rightPanel: RightPanelId | null;
   selectedAssetId: string;
   selectedMaterialId: string;
   viewMode: ViewModeId;
@@ -17,7 +18,8 @@ type UiStore = {
 
 export const uiStore = proxy<UiStore>({
   activeViewportId: "perspective",
-  rightPanel: "scene",
+  copilotPanelOpen: false,
+  rightPanel: null,
   selectedAssetId: "asset:model:crate",
   selectedMaterialId: "material:blockout:concrete",
   viewMode: "3d-only",

--- a/apps/editor/src/viewport/components/ScenePreview.tsx
+++ b/apps/editor/src/viewport/components/ScenePreview.tsx
@@ -1702,7 +1702,7 @@ function resolvePreviewMaterialSide(side?: MaterialRenderSide): Side {
     case "double":
       return DoubleSide;
     default:
-      return FrontSide;
+      return DoubleSide;
   }
 }
 

--- a/apps/editor/vite.config.ts
+++ b/apps/editor/vite.config.ts
@@ -2,6 +2,7 @@ import { searchForWorkspaceRoot, defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import tsconfigPaths from "vite-tsconfig-paths";
 import tailwindcss from "@tailwindcss/vite";
+import { createCodexBridgePlugin } from "./server/codex-bridge-plugin";
 import { createObjectGenerationApiPlugin } from "./server/object-generation-api";
 import { createTextureGenerationApiPlugin } from "./server/texture-generation-api";
 
@@ -24,6 +25,7 @@ export default defineConfig(({ mode }) => {
       react(),
       tsconfigPaths(),
       tailwindcss(),
+      createCodexBridgePlugin(),
       createObjectGenerationApiPlugin(),
       createTextureGenerationApiPlugin()
     ],

--- a/packages/editor-core/src/document/scene-document.ts
+++ b/packages/editor-core/src/document/scene-document.ts
@@ -1,7 +1,6 @@
 import type {
   Asset,
   AssetID,
-  BrushNode,
   Entity,
   EntityID,
   GeometryNode,
@@ -253,34 +252,6 @@ export function loadSceneDocumentSnapshot(scene: SceneDocument, snapshot: SceneD
 
 export function createSeedSceneDocument(): SceneDocument {
   const document = createSceneDocument();
-
-  const blockoutBrush: BrushNode = {
-    id: "node:brush:blockout-room",
-    kind: "brush",
-    name: "Blockout Room",
-    transform: makeTransform(vec3(0, 1.5, 0)),
-    data: {
-      previewSize: vec3(8, 3, 8),
-      planes: [
-        { normal: vec3(1, 0, 0), distance: 4 },
-        { normal: vec3(-1, 0, 0), distance: 4 },
-        { normal: vec3(0, 1, 0), distance: 1.5 },
-        { normal: vec3(0, -1, 0), distance: 1.5 },
-        { normal: vec3(0, 0, 1), distance: 4 },
-        { normal: vec3(0, 0, -1), distance: 4 }
-      ],
-      faces: [
-        { id: "face:brush:blockout-room:0", materialId: "material:blockout:concrete", plane: { normal: vec3(1, 0, 0), distance: 4 }, vertexIds: [] },
-        { id: "face:brush:blockout-room:1", materialId: "material:blockout:concrete", plane: { normal: vec3(-1, 0, 0), distance: 4 }, vertexIds: [] },
-        { id: "face:brush:blockout-room:2", materialId: "material:blockout:concrete", plane: { normal: vec3(0, 1, 0), distance: 1.5 }, vertexIds: [] },
-        { id: "face:brush:blockout-room:3", materialId: "material:blockout:concrete", plane: { normal: vec3(0, -1, 0), distance: 1.5 }, vertexIds: [] },
-        { id: "face:brush:blockout-room:4", materialId: "material:blockout:concrete", plane: { normal: vec3(0, 0, 1), distance: 4 }, vertexIds: [] },
-        { id: "face:brush:blockout-room:5", materialId: "material:blockout:concrete", plane: { normal: vec3(0, 0, -1), distance: 4 }, vertexIds: [] }
-      ]
-    }
-  };
-
-  document.nodes.set(blockoutBrush.id, blockoutBrush);
 
   document.layers.set("layer:default", {
     id: "layer:default",

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -317,8 +317,8 @@ export function createDefaultSceneSettings(): SceneSettings {
       ambientColor: "#ffffff",
       ambientIntensity: 0.4,
       fogColor: "#0b1118",
-      fogFar: 180,
-      fogNear: 45,
+      fogFar: 2000,
+      fogNear: 500,
       gravity: vec3(0, -9.81, 0),
       physicsEnabled: true
     }


### PR DESCRIPTION
## Summary

- **AI Vibe copilot**: LLM-powered natural language level design. Users describe what to build and watch the editor construct it in real-time via function calling. **45 tools** covering placement, transforms, materials, mesh editing, brush ops, scene settings, and queries.
- **Dual provider support**: Codex CLI (default, local) and Gemini API (remote), switchable in settings.
- **Full mesh editing**: Extrude, bevel, subdivide, cut, merge, fill, arc, inflate, invert normals, convert brush to mesh — all exposed to the copilot with topology query support.
- **Inspector panel toggle**: Clicking an active tab collapses the sidebar to just the tab strip.
- **Backface culling fix**: Default material side changed to `DoubleSide` so room shell meshes are visible from all camera angles.
- **Fog defaults relaxed**: Near/far pushed from 45/180 to 500/2000.
- **Empty start scene**: Removed the default blockout room for a clean canvas.

## Tool Coverage (45 tools, ~80% of editor operations)

| Category | Tools | Count |
|----------|-------|-------|
| Placement | rooms, platforms, stairs, primitives, brushes, lights, entities | 7 |
| Transform | translate, set transform, duplicate, mirror, delete | 5 |
| Brush | split, split at coordinate, extrude, offset face, assign material | 5 |
| Mesh Editing | extrude faces/edge, bevel, subdivide, cut, delete/merge faces, merge vertices, fill, invert normals, arc, inflate, convert brush→mesh | 14 |
| Materials | create, assign, set UV scale | 3 |
| Scene | group, select, clear selection, undo, set settings | 5 |
| Queries | list nodes/entities/materials, get node details, get scene settings, get mesh topology | 6 |

## Codex CLI Provider

Integrates OpenAI Codex App Server as a local subprocess managed by the Vite dev server. No API key needed — uses local `codex login` session.

```
Browser → WebSocket (/ws/codex) → Vite server → codex app-server (stdio)
                                                        ↓
                                              dynamic tool calls
                                                        ↓
Browser executes tools against EditorCore ← WebSocket ← Vite server
```

- `codex app-server` spawned per session with `experimentalApi: true`
- 45 editor tools registered as dynamic tools via JSON-RPC
- Models: GPT-5.4 (default), GPT-5.3 Codex, GPT-5.1 Codex Max, GPT-4.1, GPT-4.1 Mini, o3, o4-mini

## Gemini API Provider

Browser-side provider using `@google/genai` SDK with function calling and agentic loop.

- Models: Gemini 3 Flash Preview, Gemini 3.1 Pro Preview
- Thought signature preservation for Gemini 3 compatibility

## Architecture

```
apps/editor/
  server/
    codex-bridge-plugin.ts            # Vite plugin: WS server + codex subprocess + JSON-RPC
  src/lib/copilot/
    types.ts                          # CopilotProvider, SessionBasedCopilotProvider, AnyCopilotProvider
    provider.ts                       # Factory dispatching to Gemini or Codex
    gemini-provider.ts                # Gemini implementation (@google/genai)
    codex-provider.ts                 # Codex implementation (WebSocket client)
    codex-ws-protocol.ts             # Shared browser↔server WS message types
    tool-declarations.ts             # 45 FunctionDeclaration schemas
    tool-executor.ts                 # Maps function calls → editor commands + geometry kernel
    system-prompt.ts                 # Dynamic prompt with spatial math, mesh editing guidance
    agentic-loop.ts                  # Multi-turn loop for request-response providers
    settings.ts                      # Per-provider settings with migration
```

## UI

- Chat sidebar panel toggled with `Cmd+L` or the bot icon in the menu bar
- Settings dialog with provider tabs (Codex CLI / Gemini API)
- Codex tab: model selector + CLI availability indicator + auth instructions
- Gemini tab: API key input + model selector
- Markdown rendering in assistant messages (headings, bold, code, lists)
- Tool execution chips, thinking/step indicator, abort button

## Test plan

- [ ] `bun run typecheck` passes
- [ ] **Codex**: `npm install -g @openai/codex` → `codex login` → Vibe settings → Codex CLI → prompt
- [ ] **Gemini**: Vibe settings → Gemini API → enter API key → prompt
- [ ] Prompt: "build a house in full detail" → rooms, furniture, lights, materials appear
- [ ] Prompt: "create a cube and extrude the top face" → mesh extrusion works
- [ ] `Ctrl+Z` undoes copilot actions one step at a time
- [ ] Rotate camera — walls visible from all angles (DoubleSide fix)
- [ ] Click active inspector tab to collapse/expand sidebar
- [ ] Abort mid-session → clean cleanup


🤖 Generated with [Claude Code](https://claude.com/claude-code)