### PR TITLE
feat: add prefab-system package

### DIFF
--- a/packages/editor-core/src/commands/node-commands/index.ts
+++ b/packages/editor-core/src/commands/node-commands/index.ts
@@ -11,3 +11,4 @@ export * from "./selection-commands";
 export * from "./settings-commands";
 export * from "./texture-commands";
 export * from "./transform-commands";
+export * from "./helpers";

--- a/packages/prefab-system/package.json
+++ b/packages/prefab-system/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@ggez/prefab-system",
+  "version": "0.0.0",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@ggez/editor-core": "workspace:*",
+    "@ggez/shared": "workspace:*"
+  }
+}

--- a/packages/prefab-system/src/index.ts
+++ b/packages/prefab-system/src/index.ts
@@ -1,0 +1,13 @@
+export * from "./types";
+export {
+  capturePrefabSnapshot,
+  decodePrefabFromAsset,
+  encodePrefabAsAsset,
+  getPrefabsFromScene
+} from "./prefab-library";
+export {
+  createDeletePrefabCommand,
+  createPlacePrefabCommand,
+  createSavePrefabCommand,
+  createUpdatePrefabCommand
+} from "./prefab-commands";

--- a/packages/prefab-system/src/prefab-commands.ts
+++ b/packages/prefab-system/src/prefab-commands.ts
@@ -1,0 +1,228 @@
+import type { GeometryNode, Entity, Material, Vec3 } from "@ggez/shared";
+import { addVec3 } from "@ggez/shared";
+import type { Command, SceneDocument } from "@ggez/editor-core";
+import { createDuplicateNodeId, createDuplicateEntityId } from "@ggez/editor-core";
+import type { PrefabDefinition } from "./types";
+import { capturePrefabSnapshot, decodePrefabFromAsset, encodePrefabAsAsset } from "./prefab-library";
+
+export function createSavePrefabCommand(
+  scene: SceneDocument,
+  nodeIds: string[],
+  name: string,
+  description = ""
+): { command: Command; prefabId: string } {
+  const prefabId = `prefab:${name.toLowerCase().replace(/\s+/g, "-")}:${Date.now()}`;
+  const snapshot = capturePrefabSnapshot(scene, nodeIds);
+
+  const prefab: PrefabDefinition = {
+    createdAt: new Date().toISOString(),
+    description,
+    entities: snapshot.entities,
+    id: prefabId,
+    materials: snapshot.materials,
+    name,
+    nodes: snapshot.nodes,
+    rootNodeIds: snapshot.rootNodeIds
+  };
+
+  const asset = encodePrefabAsAsset(prefab);
+
+  return {
+    command: {
+      label: "save prefab",
+      execute(nextScene) {
+        nextScene.setAsset(structuredClone(asset));
+        nextScene.touch();
+      },
+      undo(nextScene) {
+        nextScene.assets.delete(prefabId);
+        nextScene.touch();
+      }
+    },
+    prefabId
+  };
+}
+
+export function createPlacePrefabCommand(
+  scene: SceneDocument,
+  prefabId: string,
+  position: Vec3
+): { command: Command; nodeIds: string[] } {
+  const asset = scene.assets.get(prefabId);
+
+  if (!asset) {
+    return {
+      command: { execute() {}, label: "place prefab", undo() {} },
+      nodeIds: []
+    };
+  }
+
+  const prefab = decodePrefabFromAsset(asset);
+
+  if (!prefab) {
+    return {
+      command: { execute() {}, label: "place prefab", undo() {} },
+      nodeIds: []
+    };
+  }
+
+  const nodeIdMap = new Map<string, string>();
+  const entityIdMap = new Map<string, string>();
+  const placedNodes: GeometryNode[] = [];
+  const placedEntities: Entity[] = [];
+  const materialsToEnsure: Material[] = [];
+  const newRootIds: string[] = [];
+
+  for (const sourceNode of prefab.nodes) {
+    const newId = createDuplicateNodeId(scene, sourceNode.id);
+    nodeIdMap.set(sourceNode.id, newId);
+  }
+
+  for (const sourceEntity of prefab.entities) {
+    const newId = createDuplicateEntityId(scene, sourceEntity.id);
+    entityIdMap.set(sourceEntity.id, newId);
+  }
+
+  for (const sourceNode of prefab.nodes) {
+    const newId = nodeIdMap.get(sourceNode.id)!;
+    const isRoot = prefab.rootNodeIds.includes(sourceNode.id);
+    const newParentId = sourceNode.parentId ? nodeIdMap.get(sourceNode.parentId) : undefined;
+
+    const placedNode: GeometryNode = structuredClone(sourceNode);
+    placedNode.id = newId;
+    placedNode.parentId = newParentId;
+
+    if (isRoot) {
+      placedNode.transform = {
+        ...placedNode.transform,
+        position: addVec3(placedNode.transform.position, position)
+      };
+      newRootIds.push(newId);
+    }
+
+    placedNodes.push(placedNode);
+  }
+
+  for (const sourceEntity of prefab.entities) {
+    const newId = entityIdMap.get(sourceEntity.id)!;
+    const newParentId = sourceEntity.parentId ? nodeIdMap.get(sourceEntity.parentId) : undefined;
+
+    const placedEntity: Entity = structuredClone(sourceEntity);
+    placedEntity.id = newId;
+    placedEntity.parentId = newParentId;
+
+    placedEntities.push(placedEntity);
+  }
+
+  for (const material of prefab.materials) {
+    if (!scene.materials.has(material.id)) {
+      materialsToEnsure.push(structuredClone(material));
+    }
+  }
+
+  return {
+    command: {
+      label: "place prefab",
+      execute(nextScene) {
+        for (const material of materialsToEnsure) {
+          if (!nextScene.materials.has(material.id)) {
+            nextScene.setMaterial(structuredClone(material));
+          }
+        }
+
+        for (const node of placedNodes) {
+          nextScene.addNode(structuredClone(node));
+        }
+
+        for (const entity of placedEntities) {
+          nextScene.addEntity(structuredClone(entity));
+        }
+
+        nextScene.touch();
+      },
+      undo(nextScene) {
+        for (const entity of placedEntities) {
+          nextScene.removeEntity(entity.id);
+        }
+
+        for (const node of [...placedNodes].reverse()) {
+          nextScene.removeNode(node.id);
+        }
+
+        for (const material of materialsToEnsure) {
+          nextScene.removeMaterial(material.id);
+        }
+
+        nextScene.touch();
+      }
+    },
+    nodeIds: newRootIds
+  };
+}
+
+export function createDeletePrefabCommand(
+  scene: SceneDocument,
+  prefabId: string
+): Command {
+  const asset = scene.assets.get(prefabId);
+
+  if (!asset || asset.type !== "prefab") {
+    return { execute() {}, label: "delete prefab", undo() {} };
+  }
+
+  const savedAsset = structuredClone(asset);
+
+  return {
+    label: "delete prefab",
+    execute(nextScene) {
+      nextScene.assets.delete(prefabId);
+      nextScene.touch();
+    },
+    undo(nextScene) {
+      nextScene.setAsset(structuredClone(savedAsset));
+      nextScene.touch();
+    }
+  };
+}
+
+export function createUpdatePrefabCommand(
+  scene: SceneDocument,
+  prefabId: string,
+  nodeIds: string[]
+): Command {
+  const existingAsset = scene.assets.get(prefabId);
+
+  if (!existingAsset || existingAsset.type !== "prefab") {
+    return { execute() {}, label: "update prefab", undo() {} };
+  }
+
+  const beforeAsset = structuredClone(existingAsset);
+  const existingPrefab = decodePrefabFromAsset(existingAsset);
+
+  if (!existingPrefab) {
+    return { execute() {}, label: "update prefab", undo() {} };
+  }
+
+  const snapshot = capturePrefabSnapshot(scene, nodeIds);
+  const updatedPrefab: PrefabDefinition = {
+    ...existingPrefab,
+    entities: snapshot.entities,
+    materials: snapshot.materials,
+    nodes: snapshot.nodes,
+    rootNodeIds: snapshot.rootNodeIds
+  };
+
+  const updatedAsset = encodePrefabAsAsset(updatedPrefab);
+
+  return {
+    label: "update prefab",
+    execute(nextScene) {
+      nextScene.setAsset(structuredClone(updatedAsset));
+      nextScene.touch();
+    },
+    undo(nextScene) {
+      nextScene.setAsset(structuredClone(beforeAsset));
+      nextScene.touch();
+    }
+  };
+}

--- a/packages/prefab-system/src/prefab-library.ts
+++ b/packages/prefab-system/src/prefab-library.ts
@@ -1,0 +1,174 @@
+import type { Asset, Entity, GeometryNode, Material } from "@ggez/shared";
+import type { SceneDocument } from "@ggez/editor-core";
+import type { PrefabDefinition, PrefabSnapshot } from "./types";
+
+const PREFAB_DATA_KEY = "prefabData";
+const PREFAB_NAME_KEY = "prefabName";
+const PREFAB_DESCRIPTION_KEY = "prefabDescription";
+
+export function encodePrefabAsAsset(prefab: PrefabDefinition): Asset {
+  const snapshot: PrefabSnapshot = {
+    entities: prefab.entities,
+    materials: prefab.materials,
+    nodes: prefab.nodes,
+    rootNodeIds: prefab.rootNodeIds
+  };
+
+  return {
+    id: prefab.id,
+    metadata: {
+      [PREFAB_DATA_KEY]: JSON.stringify(snapshot),
+      [PREFAB_DESCRIPTION_KEY]: prefab.description,
+      [PREFAB_NAME_KEY]: prefab.name,
+      createdAt: prefab.createdAt
+    },
+    path: "",
+    type: "prefab"
+  };
+}
+
+export function decodePrefabFromAsset(asset: Asset): PrefabDefinition | undefined {
+  if (asset.type !== "prefab") {
+    return undefined;
+  }
+
+  const raw = asset.metadata[PREFAB_DATA_KEY];
+
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+
+  try {
+    const snapshot = JSON.parse(raw) as PrefabSnapshot;
+
+    return {
+      createdAt: typeof asset.metadata.createdAt === "string" ? asset.metadata.createdAt : new Date().toISOString(),
+      description: typeof asset.metadata[PREFAB_DESCRIPTION_KEY] === "string" ? asset.metadata[PREFAB_DESCRIPTION_KEY] : "",
+      entities: snapshot.entities ?? [],
+      id: asset.id,
+      materials: snapshot.materials ?? [],
+      name: typeof asset.metadata[PREFAB_NAME_KEY] === "string" ? asset.metadata[PREFAB_NAME_KEY] : asset.id,
+      nodes: snapshot.nodes ?? [],
+      rootNodeIds: snapshot.rootNodeIds ?? []
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export function getPrefabsFromScene(scene: SceneDocument): PrefabDefinition[] {
+  const prefabs: PrefabDefinition[] = [];
+
+  scene.assets.forEach((asset) => {
+    const prefab = decodePrefabFromAsset(asset);
+
+    if (prefab) {
+      prefabs.push(prefab);
+    }
+  });
+
+  return prefabs;
+}
+
+export function capturePrefabSnapshot(
+  scene: SceneDocument,
+  nodeIds: string[]
+): PrefabSnapshot {
+  const selectedNodeIdSet = new Set(nodeIds);
+  const collectedNodeIds = new Set<string>();
+  const collectedNodes: GeometryNode[] = [];
+  const collectedEntities: Entity[] = [];
+  const referencedMaterialIds = new Set<string>();
+
+  function collectNodeTree(nodeId: string) {
+    if (collectedNodeIds.has(nodeId)) {
+      return;
+    }
+
+    const node = scene.getNode(nodeId);
+
+    if (!node) {
+      return;
+    }
+
+    collectedNodeIds.add(nodeId);
+    collectedNodes.push(structuredClone(node));
+
+    if (node.kind === "brush" && node.data.faces) {
+      for (const face of node.data.faces) {
+        if (face.materialId) {
+          referencedMaterialIds.add(face.materialId);
+        }
+      }
+    }
+
+    if (node.kind === "primitive" && node.data.materialId) {
+      referencedMaterialIds.add(node.data.materialId);
+    }
+
+    if (node.kind === "mesh" && node.data.faces) {
+      for (const face of node.data.faces) {
+        if (face.materialId) {
+          referencedMaterialIds.add(face.materialId);
+        }
+      }
+    }
+
+    scene.nodes.forEach((child) => {
+      if (child.parentId === nodeId) {
+        collectNodeTree(child.id);
+      }
+    });
+
+    scene.entities.forEach((entity) => {
+      if (entity.parentId === nodeId) {
+        collectedEntities.push(structuredClone(entity));
+      }
+    });
+  }
+
+  nodeIds.forEach((id) => collectNodeTree(id));
+
+  const rootNodeIds = nodeIds.filter((id) => {
+    const node = scene.getNode(id);
+
+    if (!node) {
+      return false;
+    }
+
+    return !node.parentId || !selectedNodeIdSet.has(node.parentId);
+  });
+
+  const relocalizedNodes = collectedNodes.map((node) => {
+    if (node.parentId && !collectedNodeIds.has(node.parentId)) {
+      return { ...node, parentId: undefined };
+    }
+
+    return node;
+  });
+
+  const relocalizedEntities = collectedEntities.map((entity) => {
+    if (entity.parentId && !collectedNodeIds.has(entity.parentId)) {
+      return { ...entity, parentId: undefined };
+    }
+
+    return entity;
+  });
+
+  const collectedMaterials: Material[] = [];
+
+  referencedMaterialIds.forEach((materialId) => {
+    const material = scene.materials.get(materialId);
+
+    if (material) {
+      collectedMaterials.push(structuredClone(material));
+    }
+  });
+
+  return {
+    entities: relocalizedEntities,
+    materials: collectedMaterials,
+    nodes: relocalizedNodes,
+    rootNodeIds
+  };
+}

--- a/packages/prefab-system/src/prefab-system.test.ts
+++ b/packages/prefab-system/src/prefab-system.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from "bun:test";
+import { vec3 } from "@ggez/shared";
+import { createSceneDocument } from "@ggez/editor-core";
+import type { GeometryNode } from "@ggez/shared";
+import {
+  capturePrefabSnapshot,
+  decodePrefabFromAsset,
+  encodePrefabAsAsset,
+  getPrefabsFromScene
+} from "./prefab-library";
+import {
+  createDeletePrefabCommand,
+  createPlacePrefabCommand,
+  createSavePrefabCommand,
+  createUpdatePrefabCommand
+} from "./prefab-commands";
+import type { PrefabDefinition } from "./types";
+
+function createTestScene() {
+  const scene = createSceneDocument();
+
+  const brush: GeometryNode = {
+    data: {
+      faces: [{ materialId: "mat:default", normal: vec3(0, 1, 0), vertices: [] }],
+      planes: [{ distance: 1, normal: vec3(0, 1, 0) }],
+      previewSize: vec3(2, 2, 2)
+    },
+    id: "node:wall",
+    kind: "brush",
+    name: "Wall",
+    transform: { position: vec3(0, 0, 0), rotation: vec3(0, 0, 0), scale: vec3(1, 1, 1) }
+  } as GeometryNode;
+
+  const child: GeometryNode = {
+    data: {
+      materialId: "mat:default",
+      physics: undefined,
+      role: "prop",
+      shape: "cube",
+      size: vec3(1, 1, 1)
+    },
+    id: "node:detail",
+    kind: "primitive",
+    name: "Detail",
+    parentId: "node:wall",
+    transform: { position: vec3(1, 0, 0), rotation: vec3(0, 0, 0), scale: vec3(0.5, 0.5, 0.5) }
+  } as GeometryNode;
+
+  scene.addNode(brush);
+  scene.addNode(child);
+  scene.setMaterial({
+    category: "flat",
+    color: "#808080",
+    id: "mat:default",
+    name: "Default"
+  });
+
+  return scene;
+}
+
+describe("PrefabLibrary", () => {
+  test("encodes and decodes prefab via asset", () => {
+    const prefab: PrefabDefinition = {
+      createdAt: "2026-01-01T00:00:00Z",
+      description: "Test prefab",
+      entities: [],
+      id: "prefab:test",
+      materials: [{ category: "flat", color: "#ff0000", id: "mat:1", name: "Red" }],
+      name: "TestPrefab",
+      nodes: [
+        {
+          data: {} as never,
+          id: "node:a",
+          kind: "group",
+          name: "GroupA",
+          transform: { position: vec3(0, 0, 0), rotation: vec3(0, 0, 0), scale: vec3(1, 1, 1) }
+        }
+      ],
+      rootNodeIds: ["node:a"]
+    };
+
+    const asset = encodePrefabAsAsset(prefab);
+    expect(asset.type).toBe("prefab");
+    expect(asset.id).toBe("prefab:test");
+
+    const decoded = decodePrefabFromAsset(asset);
+    expect(decoded).toBeDefined();
+    expect(decoded!.name).toBe("TestPrefab");
+    expect(decoded!.nodes.length).toBe(1);
+    expect(decoded!.nodes[0].id).toBe("node:a");
+    expect(decoded!.materials.length).toBe(1);
+    expect(decoded!.rootNodeIds).toEqual(["node:a"]);
+  });
+
+  test("returns undefined for non-prefab asset", () => {
+    const asset = {
+      id: "asset:model",
+      metadata: {},
+      path: "/models/test.glb",
+      type: "model" as const
+    };
+
+    expect(decodePrefabFromAsset(asset)).toBeUndefined();
+  });
+
+  test("captures subtree with children and materials", () => {
+    const scene = createTestScene();
+    const snapshot = capturePrefabSnapshot(scene, ["node:wall"]);
+
+    expect(snapshot.nodes.length).toBe(2);
+    expect(snapshot.rootNodeIds).toEqual(["node:wall"]);
+    expect(snapshot.materials.length).toBe(1);
+    expect(snapshot.materials[0].id).toBe("mat:default");
+  });
+
+  test("getPrefabsFromScene returns stored prefabs", () => {
+    const scene = createTestScene();
+    const prefab: PrefabDefinition = {
+      createdAt: "2026-01-01T00:00:00Z",
+      description: "",
+      entities: [],
+      id: "prefab:room",
+      materials: [],
+      name: "Room",
+      nodes: [],
+      rootNodeIds: []
+    };
+
+    scene.setAsset(encodePrefabAsAsset(prefab));
+
+    const prefabs = getPrefabsFromScene(scene);
+    expect(prefabs.length).toBe(1);
+    expect(prefabs[0].name).toBe("Room");
+  });
+});
+
+describe("PrefabCommands", () => {
+  test("save prefab creates asset", () => {
+    const scene = createTestScene();
+    const { command, prefabId } = createSavePrefabCommand(scene, ["node:wall"], "MyWall");
+
+    command.execute(scene);
+
+    const asset = scene.assets.get(prefabId);
+    expect(asset).toBeDefined();
+    expect(asset!.type).toBe("prefab");
+
+    const decoded = decodePrefabFromAsset(asset!);
+    expect(decoded!.name).toBe("MyWall");
+    expect(decoded!.nodes.length).toBe(2);
+  });
+
+  test("save prefab undo removes asset", () => {
+    const scene = createTestScene();
+    const { command, prefabId } = createSavePrefabCommand(scene, ["node:wall"], "MyWall");
+
+    command.execute(scene);
+    expect(scene.assets.has(prefabId)).toBe(true);
+
+    command.undo(scene);
+    expect(scene.assets.has(prefabId)).toBe(false);
+  });
+
+  test("place prefab creates new nodes with unique ids", () => {
+    const scene = createTestScene();
+    const { command: saveCmd, prefabId } = createSavePrefabCommand(scene, ["node:wall"], "MyWall");
+    saveCmd.execute(scene);
+
+    const nodeCountBefore = scene.nodes.size;
+    const { command: placeCmd, nodeIds } = createPlacePrefabCommand(scene, prefabId, vec3(10, 0, 0));
+    placeCmd.execute(scene);
+
+    expect(scene.nodes.size).toBe(nodeCountBefore + 2);
+    expect(nodeIds.length).toBe(1);
+
+    const rootNode = scene.getNode(nodeIds[0]);
+    expect(rootNode).toBeDefined();
+    expect(rootNode!.transform.position.x).toBe(10);
+  });
+
+  test("place prefab undo removes placed nodes", () => {
+    const scene = createTestScene();
+    const { command: saveCmd, prefabId } = createSavePrefabCommand(scene, ["node:wall"], "MyWall");
+    saveCmd.execute(scene);
+
+    const nodeCountBefore = scene.nodes.size;
+    const { command: placeCmd } = createPlacePrefabCommand(scene, prefabId, vec3(10, 0, 0));
+    placeCmd.execute(scene);
+    expect(scene.nodes.size).toBe(nodeCountBefore + 2);
+
+    placeCmd.undo(scene);
+    expect(scene.nodes.size).toBe(nodeCountBefore);
+  });
+
+  test("place prefab materials are added and removed on undo", () => {
+    const scene = createTestScene();
+    const { command: saveCmd, prefabId } = createSavePrefabCommand(scene, ["node:wall"], "MyWall");
+    saveCmd.execute(scene);
+
+    scene.removeMaterial("mat:default");
+    expect(scene.materials.has("mat:default")).toBe(false);
+
+    const { command: placeCmd } = createPlacePrefabCommand(scene, prefabId, vec3(5, 0, 0));
+    placeCmd.execute(scene);
+    expect(scene.materials.has("mat:default")).toBe(true);
+
+    placeCmd.undo(scene);
+    expect(scene.materials.has("mat:default")).toBe(false);
+  });
+
+  test("update prefab replaces snapshot", () => {
+    const scene = createTestScene();
+    const { command: saveCmd, prefabId } = createSavePrefabCommand(scene, ["node:wall"], "MyWall");
+    saveCmd.execute(scene);
+
+    const beforeAsset = scene.assets.get(prefabId)!;
+    const beforePrefab = decodePrefabFromAsset(beforeAsset)!;
+    expect(beforePrefab.nodes.length).toBe(2);
+
+    const updateCmd = createUpdatePrefabCommand(scene, prefabId, ["node:detail"]);
+    updateCmd.execute(scene);
+
+    const afterAsset = scene.assets.get(prefabId)!;
+    const afterPrefab = decodePrefabFromAsset(afterAsset)!;
+    expect(afterPrefab.nodes.length).toBe(1);
+    expect(afterPrefab.nodes[0].id).toBe("node:detail");
+
+    updateCmd.undo(scene);
+    const restoredAsset = scene.assets.get(prefabId)!;
+    const restoredPrefab = decodePrefabFromAsset(restoredAsset)!;
+    expect(restoredPrefab.nodes.length).toBe(2);
+  });
+
+  test("delete prefab removes asset", () => {
+    const scene = createTestScene();
+    const { command: saveCmd, prefabId } = createSavePrefabCommand(scene, ["node:wall"], "MyWall");
+    saveCmd.execute(scene);
+    expect(scene.assets.has(prefabId)).toBe(true);
+
+    const deleteCmd = createDeletePrefabCommand(scene, prefabId);
+    deleteCmd.execute(scene);
+    expect(scene.assets.has(prefabId)).toBe(false);
+
+    deleteCmd.undo(scene);
+    expect(scene.assets.has(prefabId)).toBe(true);
+  });
+});

--- a/packages/prefab-system/src/types.ts
+++ b/packages/prefab-system/src/types.ts
@@ -1,0 +1,19 @@
+import type { Entity, GeometryNode, Material } from "@ggez/shared";
+
+export type PrefabDefinition = {
+  createdAt: string;
+  description: string;
+  entities: Entity[];
+  id: string;
+  materials: Material[];
+  name: string;
+  nodes: GeometryNode[];
+  rootNodeIds: string[];
+};
+
+export type PrefabSnapshot = {
+  entities: Entity[];
+  materials: Material[];
+  nodes: GeometryNode[];
+  rootNodeIds: string[];
+};

--- a/packages/prefab-system/tsconfig.json
+++ b/packages/prefab-system/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,7 +30,8 @@
       "@ggez/runtime-streaming": ["packages/runtime-streaming/src/index.ts"],
       "@ggez/three-runtime": ["packages/three-runtime/src/index.ts"],
       "@ggez/tool-system": ["packages/tool-system/src/index.ts"],
-      "@ggez/workers": ["packages/workers/src/index.ts"]
+      "@ggez/workers": ["packages/workers/src/index.ts"],
+      "@ggez/prefab-system": ["packages/prefab-system/src/index.ts"]
     }
   }
 }


### PR DESCRIPTION
## Summary

New `@web-hammer/prefab-system` workspace package.

- **PrefabDefinition** stored as Assets (`type: "prefab"`) with JSON-serialized node subtree snapshots including children, entities, and materials
- Editor commands: **save**, **place**, **update**, **delete** — all with full undo/redo support
- 10 tests
- `editor-core` helpers (`createDuplicateNodeId`, etc.) now publicly exported

**Fully independent** — no dependencies on runtime-audio or runtime-particles.

## Test plan

- [ ] `bun test` passes for prefab-system (10 tests)
- [ ] `bun run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Split from #2_