### PR TITLE
feat: add runtime-audio package

### DIFF
--- a/apps/editor/src/components/editor-shell/GameplayPanels.tsx
+++ b/apps/editor/src/components/editor-shell/GameplayPanels.tsx
@@ -19,6 +19,7 @@ import {
   formatGameplayValue,
   getGameplayValue,
   getHookDefinition,
+  getPresetsForHookType,
   HOOK_DEFINITIONS,
   isGameplayObject,
   isHookFieldVisible,
@@ -604,8 +605,40 @@ function HookCard({
           </Button>
         </div>
       </div>
+      <PresetSelector hook={hook} onUpdate={onUpdate} />
       <div className="mt-3 grid gap-2">
         {children}
+      </div>
+    </div>
+  );
+}
+
+function PresetSelector({ hook, onUpdate }: { hook: SceneHook; onUpdate: (hook: SceneHook) => void }) {
+  const presets = getPresetsForHookType(hook.type);
+
+  if (presets.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2 flex items-center gap-2">
+      <span className="text-[11px] text-foreground/50">Preset</span>
+      <div className="flex flex-wrap gap-1">
+        {presets.map((preset) => (
+          <button
+            className="rounded-md border border-foreground/10 bg-foreground/[0.04] px-2 py-0.5 text-[11px] text-foreground/70 transition hover:bg-foreground/[0.08] hover:text-foreground"
+            key={preset.label}
+            onClick={() => {
+              onUpdate({
+                ...hook,
+                config: structuredClone(preset.config)
+              });
+            }}
+            type="button"
+          >
+            {preset.label}
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/apps/editor/src/lib/gameplay.ts
+++ b/apps/editor/src/lib/gameplay.ts
@@ -761,21 +761,42 @@ const hookDefinitionEntries: Array<HookDefinition & { defaultConfig: SceneHook["
   {
     category: "Feedback",
     defaultConfig: {
-      eventMap: {
-        "open.started": "door_metal_open"
-      },
+      autoplay: false,
       loop: false,
-      spatial: true
+      maxDistance: 50,
+      refDistance: 1,
+      rolloffFactor: 1,
+      spatial: true,
+      src: "",
+      stopEvent: "",
+      triggerEvent: "",
+      volume: 1
     },
-    description: "Plays audio cues in response to gameplay events.",
-    emits: ["audio.started", "audio.stopped"],
+    description: "Plays spatial or 2D audio, triggered by events or on scene start.",
+    emits: ["audio.started", "audio.ended", "audio.stopped"],
     fields: [
       {
-        kind: "event-map",
-        label: "Event Map",
-        path: "eventMap",
-        valueLabel: "Audio Cue",
-        valuePlaceholder: "door_metal_open"
+        kind: "text",
+        label: "Source URL",
+        path: "src",
+        placeholder: "/sounds/ambient.mp3"
+      },
+      {
+        kind: "number",
+        label: "Volume",
+        min: 0,
+        path: "volume",
+        step: 0.05
+      },
+      {
+        kind: "boolean",
+        label: "Autoplay",
+        path: "autoplay"
+      },
+      {
+        kind: "boolean",
+        label: "Loop",
+        path: "loop"
       },
       {
         kind: "boolean",
@@ -783,13 +804,41 @@ const hookDefinitionEntries: Array<HookDefinition & { defaultConfig: SceneHook["
         path: "spatial"
       },
       {
-        kind: "boolean",
-        label: "Loop",
-        path: "loop"
+        kind: "number",
+        label: "Ref Distance",
+        min: 0,
+        path: "refDistance",
+        step: 0.5
+      },
+      {
+        kind: "number",
+        label: "Max Distance",
+        min: 0,
+        path: "maxDistance",
+        step: 1
+      },
+      {
+        kind: "number",
+        label: "Rolloff Factor",
+        min: 0,
+        path: "rolloffFactor",
+        step: 0.1
+      },
+      {
+        kind: "text",
+        label: "Trigger Event",
+        path: "triggerEvent",
+        placeholder: "trigger.enter"
+      },
+      {
+        kind: "text",
+        label: "Stop Event",
+        path: "stopEvent",
+        placeholder: "trigger.exit"
       }
     ],
     label: "Audio Emitter",
-    listens: ["audio.play", "audio.stop"],
+    listens: ["audio.play", "audio.stop", "audio.stop_all"],
     type: "audio_emitter"
   },
   {
@@ -991,6 +1040,7 @@ export const STANDARD_GAMEPLAY_EVENTS: SceneEventDefinition[] = [
   createStandardEvent("audio.stop", "Feedback", "Audio stop request."),
   createStandardEvent("audio.started", "Feedback", "Audio playback started."),
   createStandardEvent("audio.stopped", "Feedback", "Audio playback stopped."),
+  createStandardEvent("audio.ended", "Feedback", "Audio playback ended naturally."),
   createStandardEvent("vfx.play", "Feedback", "VFX play request."),
   createStandardEvent("vfx.stop", "Feedback", "VFX stop request."),
   createStandardEvent("flag.set", "Flags", "Flag set request."),
@@ -1004,6 +1054,44 @@ export const STANDARD_GAMEPLAY_EVENTS: SceneEventDefinition[] = [
   createStandardEvent("condition.met", "Logic", "Condition listener completed successfully."),
   createStandardEvent("condition.failed", "Logic", "Condition listener failed or timed out.")
 ];
+
+export type HookPreset = {
+  config: SceneHook["config"];
+  hookType: string;
+  label: string;
+};
+
+export const HOOK_PRESETS: HookPreset[] = [
+  {
+    config: { autoplay: true, loop: true, maxDistance: 50, refDistance: 1, rolloffFactor: 1, spatial: true, src: "", volume: 0.3 },
+    hookType: "audio_emitter",
+    label: "Ambient Loop"
+  },
+  {
+    config: { autoplay: false, loop: false, maxDistance: 30, refDistance: 1, rolloffFactor: 1, spatial: true, src: "", triggerEvent: "trigger.enter", volume: 0.8 },
+    hookType: "audio_emitter",
+    label: "Trigger Sound"
+  },
+  {
+    config: { autoplay: false, loop: false, maxDistance: 20, refDistance: 1, rolloffFactor: 1, spatial: true, src: "", triggerEvent: "open.started", volume: 0.7 },
+    hookType: "audio_emitter",
+    label: "Door Sound"
+  },
+  {
+    config: { autoplay: false, loop: false, maxDistance: 15, refDistance: 0.5, rolloffFactor: 1.5, spatial: true, src: "", triggerEvent: "damage.received", volume: 1 },
+    hookType: "audio_emitter",
+    label: "Hit Sound"
+  },
+  {
+    config: { autoplay: true, loop: true, spatial: false, src: "", volume: 0.4 },
+    hookType: "audio_emitter",
+    label: "Music (2D)"
+  }
+];
+
+export function getPresetsForHookType(hookType: string): HookPreset[] {
+  return HOOK_PRESETS.filter((preset) => preset.hookType === hookType);
+}
 
 export function createGameplayEventDefinition(
   input: Pick<SceneEventDefinition, "description" | "name"> & Partial<Omit<SceneEventDefinition, "description" | "name">>

--- a/packages/gameplay-runtime/src/systems.ts
+++ b/packages/gameplay-runtime/src/systems.ts
@@ -104,7 +104,7 @@ export const GAMEPLAY_SYSTEM_BLUEPRINTS: GameplaySystemBlueprint[] = [
     description: "Routes gameplay events to audio playback.",
     hookTypes: ["audio_emitter"],
     id: "audio",
-    implemented: false,
+    implemented: true,
     label: "AudioSystem"
   },
   {

--- a/packages/runtime-audio/package.json
+++ b/packages/runtime-audio/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@ggez/runtime-audio",
+  "version": "0.0.0",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@ggez/gameplay-runtime": "workspace:*",
+    "@ggez/shared": "workspace:*"
+  }
+}

--- a/packages/runtime-audio/src/audio-engine.ts
+++ b/packages/runtime-audio/src/audio-engine.ts
@@ -1,0 +1,212 @@
+import type { Vec3 } from "@ggez/shared";
+import type { AudioEngine, AudioEngineOptions, AudioSourceHandle, PlayAudioRequest } from "./types";
+
+type ActiveSource = {
+  gainNode: GainNode;
+  handle: AudioSourceHandle;
+  pannerNode?: PannerNode;
+  sourceNode: AudioBufferSourceNode;
+};
+
+export function createAudioEngine(options: AudioEngineOptions = {}): AudioEngine {
+  const maxConcurrent = options.maxConcurrentSources ?? 32;
+  const context = new AudioContext();
+  const masterGain = context.createGain();
+  masterGain.connect(context.destination);
+
+  const bufferCache = new Map<string, Promise<AudioBuffer>>();
+  const activeSources = new Map<string, ActiveSource>();
+  let handleCounter = 0;
+
+  function loadBuffer(src: string): Promise<AudioBuffer> {
+    const cached = bufferCache.get(src);
+
+    if (cached) {
+      return cached;
+    }
+
+    const pending = (async () => {
+      try {
+        let arrayBuffer: ArrayBuffer;
+
+        if (src.startsWith("data:")) {
+          const commaIndex = src.indexOf(",");
+          const base64 = src.slice(commaIndex + 1);
+          const binary = atob(base64);
+          const bytes = new Uint8Array(binary.length);
+
+          for (let i = 0; i < binary.length; i += 1) {
+            bytes[i] = binary.charCodeAt(i);
+          }
+
+          arrayBuffer = bytes.buffer;
+        } else {
+          const response = await fetch(src);
+          arrayBuffer = await response.arrayBuffer();
+        }
+
+        return await context.decodeAudioData(arrayBuffer);
+      } catch (error) {
+        bufferCache.delete(src);
+        throw error;
+      }
+    })();
+
+    bufferCache.set(src, pending);
+    return pending;
+  }
+
+  function createHandle(emitterId: string): AudioSourceHandle {
+    handleCounter += 1;
+    return { emitterId, id: `audio:${handleCounter}` };
+  }
+
+  function stopSource(source: ActiveSource) {
+    try {
+      source.sourceNode.stop();
+    } catch {
+      // already stopped
+    }
+
+    source.sourceNode.disconnect();
+    source.gainNode.disconnect();
+    source.pannerNode?.disconnect();
+  }
+
+  return {
+    dispose() {
+      activeSources.forEach(stopSource);
+      activeSources.clear();
+      bufferCache.clear();
+      context.close().catch(() => {});
+    },
+
+    isPlaying(handle) {
+      return activeSources.has(handle.id);
+    },
+
+    async resume() {
+      if (context.state === "suspended") {
+        await context.resume();
+      }
+    },
+
+    async play(request: PlayAudioRequest) {
+      if (context.state === "suspended") {
+        await context.resume();
+      }
+
+      if (activeSources.size >= maxConcurrent) {
+        const oldest = activeSources.keys().next().value;
+
+        if (oldest) {
+          const source = activeSources.get(oldest);
+
+          if (source) {
+            stopSource(source);
+          }
+
+          activeSources.delete(oldest);
+        }
+      }
+
+      const buffer = await loadBuffer(request.src);
+      const handle = createHandle(request.src);
+      const sourceNode = context.createBufferSource();
+      sourceNode.buffer = buffer;
+      sourceNode.loop = request.loop ?? false;
+
+      const gainNode = context.createGain();
+      gainNode.gain.value = request.volume ?? 1;
+
+      let pannerNode: PannerNode | undefined;
+
+      if (request.spatial) {
+        pannerNode = context.createPanner();
+        pannerNode.distanceModel = request.spatial.distanceModel ?? "inverse";
+        pannerNode.refDistance = request.spatial.refDistance ?? 1;
+        pannerNode.maxDistance = request.spatial.maxDistance ?? 50;
+        pannerNode.rolloffFactor = request.spatial.rolloffFactor ?? 1;
+
+        if (request.spatial.position) {
+          pannerNode.positionX.value = request.spatial.position.x;
+          pannerNode.positionY.value = request.spatial.position.y;
+          pannerNode.positionZ.value = request.spatial.position.z;
+        }
+
+        sourceNode.connect(gainNode);
+        gainNode.connect(pannerNode);
+        pannerNode.connect(masterGain);
+      } else {
+        sourceNode.connect(gainNode);
+        gainNode.connect(masterGain);
+      }
+
+      const active: ActiveSource = { gainNode, handle, pannerNode, sourceNode };
+      activeSources.set(handle.id, active);
+
+      sourceNode.onended = () => {
+        if (activeSources.has(handle.id)) {
+          activeSources.delete(handle.id);
+          sourceNode.disconnect();
+          gainNode.disconnect();
+          pannerNode?.disconnect();
+        }
+      };
+
+      sourceNode.start();
+      return handle;
+    },
+
+    setListenerOrientation(forward: Vec3, up: Vec3) {
+      const listener = context.listener;
+
+      if (listener.forwardX) {
+        listener.forwardX.value = forward.x;
+        listener.forwardY.value = forward.y;
+        listener.forwardZ.value = forward.z;
+        listener.upX.value = up.x;
+        listener.upY.value = up.y;
+        listener.upZ.value = up.z;
+      }
+    },
+
+    setListenerPosition(position: Vec3) {
+      const listener = context.listener;
+
+      if (listener.positionX) {
+        listener.positionX.value = position.x;
+        listener.positionY.value = position.y;
+        listener.positionZ.value = position.z;
+      }
+    },
+
+    setMasterVolume(volume: number) {
+      masterGain.gain.value = Math.max(0, Math.min(1, volume));
+    },
+
+    setSourcePosition(handle: AudioSourceHandle, position: Vec3) {
+      const source = activeSources.get(handle.id);
+
+      if (source?.pannerNode) {
+        source.pannerNode.positionX.value = position.x;
+        source.pannerNode.positionY.value = position.y;
+        source.pannerNode.positionZ.value = position.z;
+      }
+    },
+
+    stop(handle: AudioSourceHandle) {
+      const source = activeSources.get(handle.id);
+
+      if (source) {
+        stopSource(source);
+        activeSources.delete(handle.id);
+      }
+    },
+
+    stopAll() {
+      activeSources.forEach(stopSource);
+      activeSources.clear();
+    }
+  };
+}

--- a/packages/runtime-audio/src/audio-system.test.ts
+++ b/packages/runtime-audio/src/audio-system.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import { vec3 } from "@ggez/shared";
+import { GameplayGame, createTriggerSystemDefinition } from "@ggez/gameplay-runtime";
+import { createAudioSystemDefinition } from "./audio-system";
+import type { AudioEngine, AudioSourceHandle, PlayAudioRequest } from "./types";
+
+function createMockAudioEngine(): AudioEngine & { played: PlayAudioRequest[]; stopped: string[] } {
+  let handleCounter = 0;
+  const activeHandles = new Set<string>();
+  const played: PlayAudioRequest[] = [];
+  const stopped: string[] = [];
+
+  return {
+    played,
+    stopped,
+    dispose() {
+      activeHandles.clear();
+    },
+    isPlaying(handle) {
+      return activeHandles.has(handle.id);
+    },
+    async play(request) {
+      handleCounter += 1;
+      const handle: AudioSourceHandle = { emitterId: request.src, id: `mock:${handleCounter}` };
+      activeHandles.add(handle.id);
+      played.push(request);
+      return handle;
+    },
+    setListenerOrientation() {},
+    setListenerPosition() {},
+    setMasterVolume() {},
+    setSourcePosition() {},
+    stop(handle) {
+      activeHandles.delete(handle.id);
+      stopped.push(handle.id);
+    },
+    stopAll() {
+      activeHandles.clear();
+      stopped.push("*");
+    }
+  };
+}
+
+describe("AudioSystem", () => {
+  test("autoplay emitters start playing on system start", () => {
+    const engine = createMockAudioEngine();
+    const game = new GameplayGame({
+      scene: {
+        entities: [],
+        nodes: [
+          {
+            data: {} as never,
+            hooks: [
+              {
+                config: { autoplay: true, loop: true, src: "/sounds/ambient.mp3", volume: 0.5 },
+                enabled: true,
+                id: "hook:audio:1",
+                type: "audio_emitter"
+              }
+            ],
+            id: "node:room",
+            kind: "group",
+            name: "Room",
+            transform: { position: vec3(0, 0, 0), rotation: vec3(0, 0, 0), scale: vec3(1, 1, 1) }
+          }
+        ]
+      },
+      systems: [createAudioSystemDefinition({ audioEngine: engine })]
+    });
+
+    game.start();
+    game.update(0.016);
+
+    expect(engine.played.length).toBe(1);
+    expect(engine.played[0].src).toBe("/sounds/ambient.mp3");
+    expect(engine.played[0].loop).toBe(true);
+    expect(engine.played[0].volume).toBe(0.5);
+
+    game.dispose();
+  });
+
+  test("event-triggered emitter plays on matching event", () => {
+    const engine = createMockAudioEngine();
+    const game = new GameplayGame({
+      scene: {
+        entities: [],
+        nodes: [
+          {
+            data: {} as never,
+            hooks: [
+              {
+                config: {
+                  radius: 5,
+                  shape: "sphere",
+                  size: [4, 4, 4]
+                },
+                enabled: true,
+                id: "hook:trigger:1",
+                type: "trigger_volume"
+              },
+              {
+                config: {
+                  src: "/sounds/door-open.mp3",
+                  triggerEvent: "trigger.enter",
+                  volume: 1
+                },
+                enabled: true,
+                id: "hook:audio:1",
+                type: "audio_emitter"
+              }
+            ],
+            id: "node:door",
+            kind: "group",
+            name: "Door",
+            transform: { position: vec3(0, 0, 0), rotation: vec3(0, 0, 0), scale: vec3(1, 1, 1) }
+          }
+        ]
+      },
+      systems: [
+        createTriggerSystemDefinition(),
+        createAudioSystemDefinition({ audioEngine: engine })
+      ]
+    });
+
+    game.start();
+
+    expect(engine.played.length).toBe(0);
+
+    game.updateActor({ id: "player", position: vec3(0, 0, 0), radius: 0.5 });
+    game.update(0.016);
+
+    expect(engine.played.length).toBe(1);
+    expect(engine.played[0].src).toBe("/sounds/door-open.mp3");
+
+    game.dispose();
+  });
+
+  test("audio.stop_all stops all sounds", () => {
+    const engine = createMockAudioEngine();
+    const game = new GameplayGame({
+      scene: {
+        entities: [],
+        nodes: [
+          {
+            data: {} as never,
+            hooks: [
+              {
+                config: { autoplay: true, src: "/sounds/music.mp3" },
+                enabled: true,
+                id: "hook:audio:1",
+                type: "audio_emitter"
+              }
+            ],
+            id: "node:bg",
+            kind: "group",
+            name: "Background",
+            transform: { position: vec3(0, 0, 0), rotation: vec3(0, 0, 0), scale: vec3(1, 1, 1) }
+          }
+        ]
+      },
+      systems: [createAudioSystemDefinition({ audioEngine: engine })]
+    });
+
+    game.start();
+    game.update(0.016);
+
+    expect(engine.played.length).toBe(1);
+
+    game.emitEvent({ event: "audio.stop_all", sourceId: "system", sourceKind: "system" });
+    game.update(0.016);
+
+    expect(engine.stopped).toContain("*");
+
+    game.dispose();
+  });
+
+  test("disabled hooks are ignored", () => {
+    const engine = createMockAudioEngine();
+    const game = new GameplayGame({
+      scene: {
+        entities: [],
+        nodes: [
+          {
+            data: {} as never,
+            hooks: [
+              {
+                config: { autoplay: true, src: "/sounds/test.mp3" },
+                enabled: false,
+                id: "hook:audio:1",
+                type: "audio_emitter"
+              }
+            ],
+            id: "node:test",
+            kind: "group",
+            name: "Test",
+            transform: { position: vec3(0, 0, 0), rotation: vec3(0, 0, 0), scale: vec3(1, 1, 1) }
+          }
+        ]
+      },
+      systems: [createAudioSystemDefinition({ audioEngine: engine })]
+    });
+
+    game.start();
+    game.update(0.016);
+
+    expect(engine.played.length).toBe(0);
+
+    game.dispose();
+  });
+});

--- a/packages/runtime-audio/src/audio-system.ts
+++ b/packages/runtime-audio/src/audio-system.ts
@@ -1,0 +1,197 @@
+import { readGameplayBoolean, readGameplayNumber, readGameplayString } from "@ggez/shared";
+import type {
+  GameplayEvent,
+  GameplayHookTarget,
+  GameplayRuntimeSystemContext,
+  GameplayRuntimeSystemDefinition
+} from "@ggez/gameplay-runtime";
+import type { AudioEmitterState, AudioEngine } from "./types";
+
+export type AudioSystemOptions = {
+  audioEngine: AudioEngine;
+};
+
+export function createAudioSystemDefinition(options: AudioSystemOptions): GameplayRuntimeSystemDefinition {
+  return {
+    description: "Routes gameplay events to spatial audio playback via audio_emitter hooks.",
+    hookTypes: ["audio_emitter"],
+    id: "audio",
+    label: "AudioSystem",
+    create(context: GameplayRuntimeSystemContext) {
+      const { audioEngine } = options;
+      const emitterStates = new Map<string, AudioEmitterState>();
+      const unsubscribers: Array<() => void> = [];
+
+      function resolveEmitterConfig(hook: GameplayHookTarget["hook"]) {
+        return {
+          autoplay: readGameplayBoolean(hook.config.autoplay, false),
+          loop: readGameplayBoolean(hook.config.loop, false),
+          maxDistance: readGameplayNumber(hook.config.maxDistance, 50),
+          refDistance: readGameplayNumber(hook.config.refDistance, 1),
+          rolloffFactor: readGameplayNumber(hook.config.rolloffFactor, 1),
+          spatial: readGameplayBoolean(hook.config.spatial, true),
+          src: readGameplayString(hook.config.src, ""),
+          stopEvent: readGameplayString(hook.config.stopEvent, ""),
+          triggerEvent: readGameplayString(hook.config.triggerEvent, ""),
+          volume: readGameplayNumber(hook.config.volume, 1)
+        };
+      }
+
+      function playEmitter(target: GameplayHookTarget) {
+        const config = resolveEmitterConfig(target.hook);
+
+        if (!config.src) {
+          return;
+        }
+
+        const state = emitterStates.get(target.hook.id);
+
+        if (state?.active && state.currentHandle) {
+          audioEngine.stop(state.currentHandle);
+        }
+
+        const worldTransform = context.getTargetWorldTransform(target.targetId);
+
+        audioEngine.play({
+          loop: config.loop,
+          spatial: config.spatial ? {
+            maxDistance: config.maxDistance,
+            position: worldTransform?.position,
+            refDistance: config.refDistance,
+            rolloffFactor: config.rolloffFactor
+          } : undefined,
+          src: config.src,
+          volume: config.volume
+        }).then((handle) => {
+          const emitterState: AudioEmitterState = {
+            active: true,
+            currentHandle: handle,
+            hookId: target.hook.id,
+            targetId: target.targetId
+          };
+
+          emitterStates.set(target.hook.id, emitterState);
+          context.emitFromHookTarget(target, "audio.started", { src: config.src });
+        }).catch((error) => {
+          console.warn("[AudioSystem] play failed:", error);
+        });
+      }
+
+      function stopEmitter(target: GameplayHookTarget) {
+        const state = emitterStates.get(target.hook.id);
+
+        if (state?.currentHandle) {
+          audioEngine.stop(state.currentHandle);
+          state.active = false;
+          state.currentHandle = undefined;
+          context.emitFromHookTarget(target, "audio.stopped");
+        }
+      }
+
+      return {
+        start() {
+          unsubscribers.push(context.eventBus.subscribe((event: GameplayEvent) => {
+            if (event.event === "audio.play" && event.targetId) {
+              context.getHookTargetsByType("audio_emitter")
+                .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+                .forEach((target) => playEmitter(target));
+              return;
+            }
+
+            if (event.event === "audio.stop" && event.targetId) {
+              context.getHookTargetsByType("audio_emitter")
+                .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+                .forEach((target) => stopEmitter(target));
+              return;
+            }
+
+            if (event.event === "audio.stop_all") {
+              audioEngine.stopAll();
+              emitterStates.forEach((state) => {
+                state.active = false;
+                state.currentHandle = undefined;
+              });
+              return;
+            }
+
+            context.getHookTargetsByType("audio_emitter")
+              .filter((target) => target.hook.enabled !== false)
+              .forEach((target) => {
+                const config = resolveEmitterConfig(target.hook);
+
+                if (config.triggerEvent && event.event === config.triggerEvent) {
+                  if (!event.targetId || event.targetId === target.targetId) {
+                    playEmitter(target);
+                  }
+                }
+
+                if (config.stopEvent && event.event === config.stopEvent) {
+                  if (!event.targetId || event.targetId === target.targetId) {
+                    stopEmitter(target);
+                  }
+                }
+              });
+          }));
+
+          context.getHookTargetsByType("audio_emitter")
+            .filter((target) => target.hook.enabled !== false)
+            .forEach((target) => {
+              const config = resolveEmitterConfig(target.hook);
+
+              emitterStates.set(target.hook.id, {
+                active: false,
+                hookId: target.hook.id,
+                targetId: target.targetId
+              });
+
+              if (config.autoplay && config.src) {
+                playEmitter(target);
+              }
+            });
+        },
+
+        stop() {
+          unsubscribers.forEach((unsub) => unsub());
+          unsubscribers.length = 0;
+          audioEngine.stopAll();
+          emitterStates.clear();
+        },
+
+        update() {
+          const actors = context.getActors();
+          const primaryActor = actors[0];
+
+          if (primaryActor) {
+            audioEngine.setListenerPosition(primaryActor.position);
+          }
+
+          const hookTargets = context.getHookTargetsByType("audio_emitter");
+
+          emitterStates.forEach((state) => {
+            if (!state.active || !state.currentHandle) {
+              return;
+            }
+
+            if (!audioEngine.isPlaying(state.currentHandle)) {
+              const target = hookTargets.find((t) => t.hook.id === state.hookId);
+
+              if (target) {
+                context.emitFromHookTarget(target, "audio.ended");
+              }
+
+              state.active = false;
+              state.currentHandle = undefined;
+              return;
+            }
+
+            const worldTransform = context.getTargetWorldTransform(state.targetId);
+
+            if (worldTransform) {
+              audioEngine.setSourcePosition(state.currentHandle, worldTransform.position);
+            }
+          });
+        }
+      };
+    }
+  };
+}

--- a/packages/runtime-audio/src/index.ts
+++ b/packages/runtime-audio/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export { createAudioEngine } from "./audio-engine";
+export { createAudioSystemDefinition } from "./audio-system";
+export type { AudioSystemOptions } from "./audio-system";

--- a/packages/runtime-audio/src/types.ts
+++ b/packages/runtime-audio/src/types.ts
@@ -1,0 +1,45 @@
+import type { Vec3 } from "@ggez/shared";
+
+export type AudioSourceHandle = {
+  id: string;
+  emitterId: string;
+};
+
+export type AudioEmitterState = {
+  active: boolean;
+  currentHandle?: AudioSourceHandle;
+  hookId: string;
+  targetId: string;
+};
+
+export type AudioEngineOptions = {
+  maxConcurrentSources?: number;
+};
+
+export type SpatialAudioParams = {
+  distanceModel?: "exponential" | "inverse" | "linear";
+  maxDistance?: number;
+  position?: Vec3;
+  refDistance?: number;
+  rolloffFactor?: number;
+};
+
+export type PlayAudioRequest = {
+  loop?: boolean;
+  spatial?: SpatialAudioParams;
+  src: string;
+  volume?: number;
+};
+
+export type AudioEngine = {
+  dispose: () => void;
+  isPlaying: (handle: AudioSourceHandle) => boolean;
+  play: (request: PlayAudioRequest) => Promise<AudioSourceHandle>;
+  resume: () => Promise<void>;
+  setListenerOrientation: (forward: Vec3, up: Vec3) => void;
+  setListenerPosition: (position: Vec3) => void;
+  setMasterVolume: (volume: number) => void;
+  setSourcePosition: (handle: AudioSourceHandle, position: Vec3) => void;
+  stop: (handle: AudioSourceHandle) => void;
+  stopAll: () => void;
+};

--- a/packages/runtime-audio/tsconfig.json
+++ b/packages/runtime-audio/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,6 +1,7 @@
 import type {
   BrushNode,
   Entity,
+  GameplayValue,
   GeometryNode,
   GroupNode,
   InstancingNode,
@@ -520,4 +521,28 @@ function matrixToTransform(matrix: Matrix4, pivot?: Vec3): Transform {
     rotation: vec3(rotation.x, rotation.y, rotation.z),
     scale: vec3(tempScale.x, tempScale.y, tempScale.z)
   };
+}
+
+export function readGameplayString(value: GameplayValue | undefined, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+export function readGameplayNumber(value: GameplayValue | undefined, fallback: number): number {
+  return typeof value === "number" ? value : fallback;
+}
+
+export function readGameplayBoolean(value: GameplayValue | undefined, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+export function readGameplayVec3(value: GameplayValue | undefined, fallback: Vec3): Vec3 {
+  if (!Array.isArray(value) || value.length < 3) {
+    return fallback;
+  }
+
+  return vec3(
+    typeof value[0] === "number" ? value[0] : fallback.x,
+    typeof value[1] === "number" ? value[1] : fallback.y,
+    typeof value[2] === "number" ? value[2] : fallback.z
+  );
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,7 +30,8 @@
       "@ggez/runtime-streaming": ["packages/runtime-streaming/src/index.ts"],
       "@ggez/three-runtime": ["packages/three-runtime/src/index.ts"],
       "@ggez/tool-system": ["packages/tool-system/src/index.ts"],
-      "@ggez/workers": ["packages/workers/src/index.ts"]
+      "@ggez/workers": ["packages/workers/src/index.ts"],
+      "@ggez/runtime-audio": ["packages/runtime-audio/src/index.ts"]
     }
   }
 }


### PR DESCRIPTION
## Summary

New `@web-hammer/runtime-audio` workspace package.

- **AudioEngine** wrapping Web Audio API with spatial 3D (PannerNode), buffer caching, and concurrent source management
- **AudioSystem** gameplay system (`audio_emitter` hook) with autoplay, loop, spatial positioning, event-triggered playback (`triggerEvent`/`stopEvent`), and direct commands (`audio.play`/`audio.stop`/`audio.stop_all`)
- 4 tests

### Also included

- `readGameplayString`/`Number`/`Boolean`/`Vec3` shared helpers in `@web-hammer/shared`
- `audio_emitter` blueprint marked as `implemented: true` in gameplay-runtime
- Expanded `audio_emitter` hook definition with full field set (src, volume, autoplay, loop, spatial, refDistance, maxDistance, rolloffFactor, triggerEvent, stopEvent)
- Audio presets: Ambient Loop, Trigger Sound, Door Sound, Hit Sound, Music (2D)
- `PresetSelector` UI component for editor hook panels
- `audio.ended` gameplay event

## Test plan

- [ ] `bun test` passes for runtime-audio (4 tests)
- [ ] `bun run typecheck` clean
- [ ] Editor: Hooks tab → add Audio Emitter → apply preset → verify fields populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Split from #2_