### PR TITLE
fix: retry atomic rename on Windows to prevent EPERM crashes

### DIFF
--- a/apps/editor/server/editor-sync-registry.ts
+++ b/apps/editor/server/editor-sync-registry.ts
@@ -163,7 +163,20 @@ async function writeDevSyncRegistry(registry: DevSyncRegistry) {
   const tempPath = `${DEV_SYNC_REGISTRY_PATH}.${process.pid}.${randomUUID()}.tmp`;
   await mkdir(dirname(DEV_SYNC_REGISTRY_PATH), { recursive: true });
   await writeFile(tempPath, JSON.stringify(registry, null, 2), "utf8");
-  await rename(tempPath, DEV_SYNC_REGISTRY_PATH);
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      await rename(tempPath, DEV_SYNC_REGISTRY_PATH);
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EPERM" && attempt < 4) {
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+        continue;
+      }
+      await rm(tempPath, { force: true });
+      throw error;
+    }
+  }
 }
 
 function pruneDevSyncRegistry(registry: DevSyncRegistry) {

--- a/packages/dev-sync/src/node.ts
+++ b/packages/dev-sync/src/node.ts
@@ -44,7 +44,21 @@ export async function writeDevSyncRegistry(registry: DevSyncRegistry) {
   const tempPath = `${DEV_SYNC_REGISTRY_PATH}.${process.pid}.${randomUUID()}.tmp`;
   await mkdir(dirname(DEV_SYNC_REGISTRY_PATH), { recursive: true });
   await writeFile(tempPath, JSON.stringify(registry, null, 2), "utf8");
-  await rename(tempPath, DEV_SYNC_REGISTRY_PATH);
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      await rename(tempPath, DEV_SYNC_REGISTRY_PATH);
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EPERM" && attempt < 4) {
+        await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+        continue;
+      }
+      // Clean up temp file on final failure
+      await rm(tempPath, { force: true });
+      throw error;
+    }
+  }
 }
 
 export function pruneDevSyncRegistry(


### PR DESCRIPTION
## Summary

- `writeDevSyncRegistry` uses an atomic write pattern (write to temp file → rename to target)
- On Windows, `fs.rename()` fails with `EPERM` when another process holds a handle on the target file
- This consistently crashes the editor when multiple Vite dev servers run concurrently (e.g. editor + playgrounds), as they all write to the same shared `web-hammer-dev-sync.json` registry in the temp directory

## Fix

Wrap the `rename()` call in a retry loop (up to 5 attempts) with progressive backoff (50ms, 100ms, 150ms, 200ms). On final failure, the orphaned temp file is cleaned up before re-throwing.

Applied to both copies of `writeDevSyncRegistry`:
- `packages/dev-sync/src/node.ts`
- `apps/editor/server/editor-sync-registry.ts`

## Test plan

- [x] Run `bun run dev:all` on Windows (editor + 2 playgrounds = 3 concurrent Vite instances)
- [x] Confirm the editor no longer crashes on startup with EPERM error

🤖 Generated with [Claude Code](https://claude.com/claude-code)