### PR TITLE
chore: use workspace:* for internal package dependencies

### DIFF
--- a/packages/editor-core/package.json
+++ b/packages/editor-core/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/vibe-stack/trident/tree/main/packages/editor-core",
   "dependencies": {
-    "@ggez/geometry-kernel": "0.1.1",
-    "@ggez/shared": "0.1.1"
+    "@ggez/geometry-kernel": "workspace:*",
+    "@ggez/shared": "workspace:*"
   }
 }

--- a/packages/gameplay-runtime/package.json
+++ b/packages/gameplay-runtime/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/vibe-stack/trident/tree/main/packages/gameplay-runtime",
   "dependencies": {
-    "@ggez/runtime-format": "0.1.1",
-    "@ggez/shared": "0.1.1"
+    "@ggez/runtime-format": "workspace:*",
+    "@ggez/shared": "workspace:*"
   }
 }

--- a/packages/geometry-kernel/package.json
+++ b/packages/geometry-kernel/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/vibe-stack/trident/tree/main/packages/geometry-kernel",
   "dependencies": {
-    "@ggez/shared": "0.1.1",
+    "@ggez/shared": "workspace:*",
     "clipper2-ts": "latest",
     "earcut": "^3.0.2"
   }

--- a/packages/render-pipeline/package.json
+++ b/packages/render-pipeline/package.json
@@ -34,8 +34,8 @@
   },
   "homepage": "https://github.com/vibe-stack/trident/tree/main/packages/render-pipeline",
   "dependencies": {
-    "@ggez/geometry-kernel": "0.1.1",
-    "@ggez/shared": "0.1.1",
+    "@ggez/geometry-kernel": "workspace:*",
+    "@ggez/shared": "workspace:*",
     "three": "^0.181.1",
     "three-mesh-bvh": "^0.9.2"
   }

--- a/packages/runtime-build/package.json
+++ b/packages/runtime-build/package.json
@@ -40,10 +40,10 @@
     "@types/three": "^0.181.0"
   },
   "dependencies": {
-    "@ggez/editor-core": "0.1.1",
-    "@ggez/geometry-kernel": "0.1.1",
-    "@ggez/runtime-format": "0.1.1",
-    "@ggez/shared": "0.1.1",
+    "@ggez/editor-core": "workspace:*",
+    "@ggez/geometry-kernel": "workspace:*",
+    "@ggez/runtime-format": "workspace:*",
+    "@ggez/shared": "workspace:*",
     "fflate": "^0.8.2",
     "three": "^0.181.1",
     "three-mesh-bvh": "^0.9.2"

--- a/packages/runtime-format/package.json
+++ b/packages/runtime-format/package.json
@@ -34,6 +34,6 @@
   },
   "homepage": "https://github.com/vibe-stack/trident/tree/main/packages/runtime-format",
   "dependencies": {
-    "@ggez/shared": "0.1.1"
+    "@ggez/shared": "workspace:*"
   }
 }

--- a/packages/runtime-physics-rapier/package.json
+++ b/packages/runtime-physics-rapier/package.json
@@ -38,9 +38,9 @@
   },
   "dependencies": {
     "@dimforge/rapier3d-compat": "^0.19.2",
-    "@ggez/render-pipeline": "0.1.1",
-    "@ggez/runtime-format": "0.1.1",
-    "@ggez/shared": "0.1.1",
+    "@ggez/render-pipeline": "workspace:*",
+    "@ggez/runtime-format": "workspace:*",
+    "@ggez/shared": "workspace:*",
     "three": "^0.181.1"
   }
 }

--- a/packages/runtime-streaming/package.json
+++ b/packages/runtime-streaming/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/vibe-stack/trident/tree/main/packages/runtime-streaming",
   "dependencies": {
-    "@ggez/runtime-format": "0.1.1",
-    "@ggez/shared": "0.1.1"
+    "@ggez/runtime-format": "workspace:*",
+    "@ggez/shared": "workspace:*"
   }
 }

--- a/packages/three-runtime/package.json
+++ b/packages/three-runtime/package.json
@@ -37,9 +37,9 @@
     "@types/three": "^0.181.0"
   },
   "dependencies": {
-    "@ggez/runtime-build": "0.1.1",
-    "@ggez/runtime-format": "0.1.1",
-    "@ggez/shared": "0.1.1",
+    "@ggez/runtime-build": "workspace:*",
+    "@ggez/runtime-format": "workspace:*",
+    "@ggez/shared": "workspace:*",
     "three": "^0.181.1"
   }
 }

--- a/packages/tool-system/package.json
+++ b/packages/tool-system/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/vibe-stack/trident/tree/main/packages/tool-system",
   "dependencies": {
-    "@ggez/shared": "0.1.1",
+    "@ggez/shared": "workspace:*",
     "xstate": "^5.24.0"
   }
 }

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -35,11 +35,11 @@
   "homepage": "https://github.com/vibe-stack/trident/tree/main/packages/workers",
   "dependencies": {
     "@types/three": "^0.181.0",
-    "@ggez/editor-core": "0.1.1",
-    "@ggez/geometry-kernel": "0.1.1",
-    "@ggez/runtime-build": "0.1.1",
-    "@ggez/runtime-format": "0.1.1",
-    "@ggez/shared": "0.1.1",
+    "@ggez/editor-core": "workspace:*",
+    "@ggez/geometry-kernel": "workspace:*",
+    "@ggez/runtime-build": "workspace:*",
+    "@ggez/runtime-format": "workspace:*",
+    "@ggez/shared": "workspace:*",
     "comlink": "^4.4.2",
     "three": "^0.181.1",
     "three-mesh-bvh": "^0.9.2"


### PR DESCRIPTION
## Summary

- Replace hardcoded `"0.1.1"` version references with `"workspace:*"` for all internal `@ggez/*` dependencies across 11 package.json files
- This ensures local development always resolves packages from the workspace rather than a published registry version, preventing version drift

## Affected packages

`editor-core`, `gameplay-runtime`, `geometry-kernel`, `render-pipeline`, `runtime-build`, `runtime-format`, `runtime-physics-rapier`, `runtime-streaming`, `three-runtime`, `tool-system`, `workers`

## Test plan

- [x] Run `bun install` — all workspace links resolve correctly
- [x] Run `bun run dev` — editor starts without dependency errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)