### PR TITLE
feat: add dev:all script for concurrent dev servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "dev": "bun run --cwd apps/editor dev",
+    "dev:all": "bun run --filter '@ggez/editor' --filter '@ggez/three-runtime-playground' --filter '@ggez/three-vanilla-playground' dev",
     "build": "bun run --cwd apps/editor build",
     "typecheck": "bun run --cwd apps/editor typecheck",
     "build:packages": "bun ./scripts/release-packages.mjs build",


### PR DESCRIPTION
## Summary

- Add a `dev:all` script to the root `package.json` that starts the editor, React playground, and Vanilla playground dev servers concurrently
- Uses `bun run --filter` to target `@ggez/editor`, `@ggez/three-runtime-playground`, and `@ggez/three-vanilla-playground`

## Test plan

- [x] Run `bun run dev:all` — all three dev servers start in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)