### PR TITLE
feat: complete audio system with mixer, spatial 3D, and 42 tests

### DIFF
--- a/apps/editor/src/lib/gameplay.ts
+++ b/apps/editor/src/lib/gameplay.ts
@@ -761,21 +761,64 @@ const hookDefinitionEntries: Array<HookDefinition & { defaultConfig: SceneHook["
   {
     category: "Feedback",
     defaultConfig: {
-      eventMap: {
-        "open.started": "door_metal_open"
-      },
+      autoPlay: false,
+      channel: "sfx",
+      clip: "",
+      distanceModel: "inverse",
       loop: false,
-      spatial: true
+      maxDistance: 10000,
+      pitch: 1,
+      refDistance: 1,
+      rolloffFactor: 1,
+      spatial: false,
+      stopEvent: "",
+      triggerEvent: "",
+      volume: 1
     },
-    description: "Plays audio cues in response to gameplay events.",
-    emits: ["audio.started", "audio.stopped"],
+    description: "Plays audio clips in response to gameplay events with optional 3D spatial positioning.",
+    emits: ["audio.play", "audio.stop"],
     fields: [
       {
-        kind: "event-map",
-        label: "Event Map",
-        path: "eventMap",
-        valueLabel: "Audio Cue",
-        valuePlaceholder: "door_metal_open"
+        kind: "text",
+        label: "Clip",
+        path: "clip",
+        placeholder: "door_open.ogg"
+      },
+      {
+        kind: "enum",
+        label: "Channel",
+        options: [
+          { label: "SFX", value: "sfx" },
+          { label: "Music", value: "music" },
+          { label: "Ambient", value: "ambient" },
+          { label: "UI", value: "ui" },
+          { label: "Voice", value: "voice" }
+        ],
+        path: "channel"
+      },
+      {
+        kind: "number",
+        label: "Volume",
+        min: 0,
+        path: "volume",
+        step: 0.05
+      },
+      {
+        kind: "number",
+        label: "Pitch",
+        min: 0.1,
+        path: "pitch",
+        step: 0.05
+      },
+      {
+        kind: "boolean",
+        label: "Loop",
+        path: "loop"
+      },
+      {
+        kind: "boolean",
+        label: "Auto Play",
+        path: "autoPlay"
       },
       {
         kind: "boolean",
@@ -783,13 +826,55 @@ const hookDefinitionEntries: Array<HookDefinition & { defaultConfig: SceneHook["
         path: "spatial"
       },
       {
-        kind: "boolean",
-        label: "Loop",
-        path: "loop"
+        kind: "enum",
+        label: "Distance Model",
+        options: [
+          { label: "Inverse", value: "inverse" },
+          { label: "Linear", value: "linear" },
+          { label: "Exponential", value: "exponential" }
+        ],
+        path: "distanceModel",
+        showWhen: { path: "spatial", equals: true }
+      },
+      {
+        kind: "number",
+        label: "Ref Distance",
+        min: 0,
+        path: "refDistance",
+        step: 0.5,
+        showWhen: { path: "spatial", equals: true }
+      },
+      {
+        kind: "number",
+        label: "Max Distance",
+        min: 0,
+        path: "maxDistance",
+        step: 1,
+        showWhen: { path: "spatial", equals: true }
+      },
+      {
+        kind: "number",
+        label: "Rolloff Factor",
+        min: 0,
+        path: "rolloffFactor",
+        step: 0.1,
+        showWhen: { path: "spatial", equals: true }
+      },
+      {
+        kind: "text",
+        label: "Trigger Event",
+        path: "triggerEvent",
+        placeholder: "open.started"
+      },
+      {
+        kind: "text",
+        label: "Stop Event",
+        path: "stopEvent",
+        placeholder: "close.completed"
       }
     ],
     label: "Audio Emitter",
-    listens: ["audio.play", "audio.stop"],
+    listens: ["audio.play", "audio.stop", "audio.stop_all"],
     type: "audio_emitter"
   },
   {

--- a/apps/three-runtime-playground/package.json
+++ b/apps/three-runtime-playground/package.json
@@ -16,6 +16,7 @@
     "@react-three/rapier": "^2.2.0",
     "@ggez/gameplay-runtime": "workspace:*",
     "@ggez/render-pipeline": "workspace:*",
+    "@ggez/runtime-audio": "workspace:*",
     "@ggez/shared": "workspace:*",
     "@ggez/three-runtime": "workspace:*",
     "lucide-react": "^0.542.0",

--- a/apps/three-runtime-playground/src/gameplay-systems.ts
+++ b/apps/three-runtime-playground/src/gameplay-systems.ts
@@ -1,4 +1,5 @@
 import {
+  createAudioSystemDefinition,
   createMoverSystemDefinition,
   createOpenableSystemDefinition,
   createPathMoverSystemDefinition,
@@ -10,6 +11,7 @@ import {
 import type { WebHammerEngineScene } from "@ggez/three-runtime";
 
 export type PlaybackGameplaySystemsState = {
+  audio: boolean;
   mover: boolean;
   openable: boolean;
   pathMover: boolean;
@@ -41,6 +43,10 @@ export function createPlaybackGameplaySystems(
 
   if (enabledSystems.pathMover) {
     systems.push(createPathMoverSystemDefinition(createScenePathResolver(scene.settings.paths ?? [])));
+  }
+
+  if (enabledSystems.audio) {
+    systems.push(createAudioSystemDefinition());
   }
 
   return systems;

--- a/apps/three-runtime-playground/src/playground/types.ts
+++ b/apps/three-runtime-playground/src/playground/types.ts
@@ -3,6 +3,7 @@ import type { RefObject } from "react";
 export type PlaygroundPhysicsPlayback = "paused" | "running" | "stopped";
 
 export type EnabledSystemsState = {
+  audio: boolean;
   mover: boolean;
   openable: boolean;
   pathMover: boolean;

--- a/apps/three-runtime-playground/src/playground/useRuntimePlayground.ts
+++ b/apps/three-runtime-playground/src/playground/useRuntimePlayground.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createGameplayRuntime, createGameplayRuntimeSceneFromRuntimeScene } from "@ggez/gameplay-runtime";
+import { createAudioManager, type AudioManager } from "@ggez/runtime-audio";
 import {
   createWebHammerBundleAssetResolver,
   parseWebHammerEngineBundleZip,
@@ -22,6 +23,7 @@ type PlayerActor = {
 };
 
 const DEFAULT_SYSTEMS: EnabledSystemsState = {
+  audio: true,
   mover: true,
   openable: true,
   pathMover: true,
@@ -62,22 +64,74 @@ export function useRuntimePlayground() {
     bundleResolverRef.current?.dispose();
   }, []);
 
+  const audioManagerRef = useRef<AudioManager | undefined>(undefined);
+
   useEffect(() => {
+    audioManagerRef.current?.dispose();
+
+    const audioManager = createAudioManager({
+      clipResolver: async (clipId) => {
+        const url = await Promise.resolve(resolveAssetPath(clipId));
+        const response = await fetch(url);
+        return response.arrayBuffer();
+      }
+    });
+    audioManagerRef.current = audioManager;
+
     hostRef.current.reset();
     setRuntimeEvents([]);
     const unsubscribe = gameplayRuntime.onEvent((event) => {
       setRuntimeEvents((current) =>
         [`${event.event}${event.targetId ? ` -> ${event.targetId}` : ""}`, ...current].slice(0, 12)
       );
+
+      if (event.event === "audio.play") {
+        const p = event.payload as Record<string, unknown> | undefined;
+        if (p?.clip && typeof p.clip === "string") {
+          void audioManager.play({
+            channel: (p.channel as "sfx" | "music" | "ambient" | "ui" | "voice") ?? "sfx",
+            clip: p.clip as string,
+            distanceModel: (p.distanceModel as "inverse" | "linear" | "exponential") ?? "inverse",
+            id: p.hookId as string | undefined,
+            loop: p.loop === true,
+            maxDistance: typeof p.maxDistance === "number" ? p.maxDistance : 10000,
+            pitch: typeof p.pitch === "number" ? p.pitch : 1,
+            position: Array.isArray(p.position) ? { x: p.position[0], y: p.position[1], z: p.position[2] } : undefined,
+            refDistance: typeof p.refDistance === "number" ? p.refDistance : 1,
+            rolloffFactor: typeof p.rolloffFactor === "number" ? p.rolloffFactor : 1,
+            spatial: p.spatial === true,
+            volume: typeof p.volume === "number" ? p.volume : 1
+          });
+        }
+      }
+
+      if (event.event === "audio.stop") {
+        const p = event.payload as Record<string, unknown> | undefined;
+        if (p?.hookId && typeof p.hookId === "string") {
+          audioManager.stop(p.hookId);
+        }
+      }
     });
 
     gameplayRuntime.start();
 
+    // Resume AudioContext on first user gesture (browsers require this).
+    const resumeAudio = () => {
+      void audioManager.resume();
+      window.removeEventListener("pointerdown", resumeAudio);
+      window.removeEventListener("keydown", resumeAudio);
+    };
+    window.addEventListener("pointerdown", resumeAudio);
+    window.addEventListener("keydown", resumeAudio);
+
     return () => {
       unsubscribe();
       gameplayRuntime.dispose();
+      audioManager.dispose();
+      window.removeEventListener("pointerdown", resumeAudio);
+      window.removeEventListener("keydown", resumeAudio);
     };
-  }, [gameplayRuntime]);
+  }, [gameplayRuntime, resolveAssetPath]);
 
   const resetPhysics = useCallback(() => {
     setPhysicsPlayback("stopped");
@@ -104,7 +158,7 @@ export function useRuntimePlayground() {
         const text = await file.text();
         bundleResolverRef.current?.dispose();
         bundleResolverRef.current = undefined;
-        nextScene = parseWebHammerEngineScene(text);
+        nextScene = parseSceneText(text);
       }
 
       setScene(nextScene);
@@ -182,4 +236,21 @@ export function useRuntimePlayground() {
     stageStats,
     status
   };
+}
+
+/** Parse scene text — handles both runtime format and .whmap editor format. */
+function parseSceneText(text: string): WebHammerEngineScene {
+  const parsed = JSON.parse(text);
+
+  if (parsed?.format === "whmap" && parsed.scene) {
+    const scene = parsed.scene;
+    scene.metadata = {
+      exportedAt: new Date().toISOString(),
+      format: "web-hammer-engine",
+      version: 6
+    };
+    return parseWebHammerEngineScene(JSON.stringify(scene));
+  }
+
+  return parseWebHammerEngineScene(text);
 }

--- a/apps/three-runtime-playground/src/sample-scene.ts
+++ b/apps/three-runtime-playground/src/sample-scene.ts
@@ -80,6 +80,20 @@ export function createSampleScene(): WebHammerEngineScene {
           uvScale: { x: 4, y: 4 }
         },
         geometry: geometryFromPrimitive(new BoxGeometry(16, 0.8, 16), floorMaterial),
+        hooks: [
+          {
+            config: {
+              autoPlay: true,
+              clip: "sample:wind",
+              loop: true,
+              spatial: false,
+              volume: 0.12
+            },
+            enabled: true,
+            id: "hook:sample:floor:wind",
+            type: "audio_emitter"
+          }
+        ],
         id: "node:sample:floor",
         kind: "primitive",
         name: "Floor",
@@ -146,6 +160,23 @@ export function createSampleScene(): WebHammerEngineScene {
             enabled: true,
             id: "hook:sample:spire:tags",
             type: "tags"
+          },
+          {
+            config: {
+              autoPlay: true,
+              clip: "sample:machinery",
+              distanceModel: "inverse",
+              loop: true,
+              maxDistance: 25,
+              pitch: 1,
+              refDistance: 2,
+              rolloffFactor: 1.5,
+              spatial: true,
+              volume: 0.3
+            },
+            enabled: true,
+            id: "hook:sample:spire:audio",
+            type: "audio_emitter"
           }
         ],
         id: "node:sample:spire-group",
@@ -219,6 +250,22 @@ export function createSampleScene(): WebHammerEngineScene {
             enabled: true,
             id: "hook:sample:door:mover",
             type: "mover"
+          },
+          {
+            config: {
+              clip: "sample:door-slide",
+              distanceModel: "inverse",
+              maxDistance: 20,
+              pitch: 1,
+              refDistance: 1,
+              rolloffFactor: 2,
+              spatial: true,
+              triggerEvent: "open.started",
+              volume: 0.8
+            },
+            enabled: true,
+            id: "hook:sample:door:audio",
+            type: "audio_emitter"
           }
         ],
         id: "node:sample:door-root",
@@ -275,6 +322,22 @@ export function createSampleScene(): WebHammerEngineScene {
             enabled: true,
             id: "hook:sample:platform:trigger",
             type: "trigger_volume"
+          },
+          {
+            config: {
+              clip: "sample:chime",
+              distanceModel: "inverse",
+              maxDistance: 30,
+              pitch: 1,
+              refDistance: 2,
+              rolloffFactor: 1,
+              spatial: true,
+              triggerEvent: "trigger.enter",
+              volume: 0.5
+            },
+            enabled: true,
+            id: "hook:sample:platform:audio",
+            type: "audio_emitter"
           },
           {
             config: {
@@ -431,12 +494,43 @@ export function createSampleScene(): WebHammerEngineScene {
   };
 }
 
+const sampleAudioCache = new Map<string, string>();
+
 export async function resolveSampleAssetPath(path: string) {
   if (path === SAMPLE_MODEL_PATH) {
     return createSampleGltfDataUrl();
   }
 
+  if (path.startsWith("sample:")) {
+    const cached = sampleAudioCache.get(path);
+    if (cached) return cached;
+
+    const url = generateSampleAudio(path);
+    if (url) {
+      sampleAudioCache.set(path, url);
+      return url;
+    }
+  }
+
   return path;
+}
+
+function generateSampleAudio(clipId: string): string | undefined {
+  switch (clipId) {
+    case "sample:wind":          return generateWind(4, 0.25);
+    case "sample:rain":          return generateRain(3, 0.2);
+    case "sample:water-stream":  return generateWaterStream(3, 0.2);
+    case "sample:ambient-hum":   return generateHum(2, 0.15, 90);
+    case "sample:machinery":     return generateHum(3, 0.2, 60);
+    case "sample:door-slide":    return generateSweep(140, 80, 0.6, 0.3);
+    case "sample:chime":         return generateChime(880, 1.2, 0.35);
+    case "sample:footstep":      return generateImpact(60, 0.08, 0.4);
+    case "sample:click":         return generateImpact(2000, 0.025, 0.3);
+    case "sample:alarm":         return generateSweep(600, 1200, 1.5, 0.2);
+    case "sample:explosion":     return generateExplosion(1.2, 0.4);
+    case "sample:pickup":        return generatePickup(0.4, 0.3);
+    default:                     return undefined;
+  }
 }
 
 function geometryFromPrimitive(geometry: BufferGeometry, material: WebHammerExportMaterial) {
@@ -621,4 +715,263 @@ function toBase64(bytes: Uint8Array) {
     binary += String.fromCharCode(value);
   });
   return btoa(binary);
+}
+
+// ---------------------------------------------------------------------------
+//  Procedural audio generators — all produce mono 16-bit WAV data URLs.
+// ---------------------------------------------------------------------------
+
+const SAMPLE_RATE = 22050;
+
+function encodeWav(samples: Float32Array): string {
+  const numSamples = samples.length;
+  const dataSize = numSamples * 2;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  writeString(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeString(view, 8, "WAVE");
+  writeString(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, SAMPLE_RATE, true);
+  view.setUint32(28, SAMPLE_RATE * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeString(view, 36, "data");
+  view.setUint32(40, dataSize, true);
+
+  for (let i = 0; i < numSamples; i++) {
+    view.setInt16(44 + i * 2, Math.max(-32768, Math.min(32767, Math.round(samples[i] * 32767))), true);
+  }
+
+  return `data:audio/wav;base64,${toBase64(new Uint8Array(buffer))}`;
+}
+
+function writeString(view: DataView, offset: number, value: string) {
+  for (let i = 0; i < value.length; i++) {
+    view.setUint8(offset + i, value.charCodeAt(i));
+  }
+}
+
+function fade(i: number, total: number, fadeMs = 20): number {
+  const fadeSamples = (SAMPLE_RATE * fadeMs) / 1000;
+  return Math.min(1, i / fadeSamples) * Math.min(1, (total - i) / fadeSamples);
+}
+
+// Seeded PRNG for deterministic noise.
+function prng(seed: number) {
+  let s = seed | 0;
+  return () => {
+    s = (s * 1103515245 + 12345) & 0x7fffffff;
+    return (s / 0x7fffffff) * 2 - 1;
+  };
+}
+
+/** Wind — layered filtered noise with slow amplitude modulation. */
+function generateWind(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(42);
+
+  // Generate raw noise then low-pass filter by averaging.
+  const raw = new Float32Array(n);
+  for (let i = 0; i < n; i++) raw[i] = noise();
+
+  // Simple moving-average low-pass (window = 60 ≈ ~370 Hz cutoff).
+  const window = 60;
+  let sum = 0;
+  for (let i = 0; i < window && i < n; i++) sum += raw[i];
+  for (let i = 0; i < n; i++) {
+    if (i >= window) sum -= raw[i - window];
+    if (i + window < n) sum += raw[i + window];
+    const filtered = sum / window;
+    // Slow modulation at ~0.3 Hz for gusts.
+    const gust = 0.5 + 0.5 * Math.sin(2 * Math.PI * 0.3 * (i / SAMPLE_RATE));
+    out[i] = filtered * amp * gust * fade(i, n, 200);
+  }
+
+  return encodeWav(out);
+}
+
+/** Rain — sparse random drops with short exponential decay. */
+function generateRain(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const rng = prng(77);
+  const dropInterval = Math.floor(SAMPLE_RATE * 0.012);
+  const decaySamples = Math.floor(SAMPLE_RATE * 0.004);
+
+  for (let i = 0; i < n; i += dropInterval) {
+    if (rng() > -0.3) {
+      const strength = 0.5 + 0.5 * Math.abs(rng());
+      for (let j = 0; j < decaySamples && i + j < n; j++) {
+        out[i + j] += rng() * amp * strength * Math.exp(-j / (decaySamples * 0.25));
+      }
+    }
+  }
+
+  // Soft low-pass.
+  for (let i = 1; i < n; i++) {
+    out[i] = out[i] * 0.6 + out[i - 1] * 0.4;
+  }
+
+  for (let i = 0; i < n; i++) out[i] *= fade(i, n, 100);
+  return encodeWav(out);
+}
+
+/** Water stream — denser noise with bandpass character. */
+function generateWaterStream(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(123);
+
+  for (let i = 0; i < n; i++) {
+    out[i] = noise();
+  }
+
+  // Bandpass: low-pass then high-pass.
+  for (let pass = 0; pass < 3; pass++) {
+    for (let i = 1; i < n; i++) {
+      out[i] = out[i] * 0.35 + out[i - 1] * 0.65;
+    }
+  }
+  // High-pass (subtract running average).
+  let avg = 0;
+  for (let i = 0; i < n; i++) {
+    avg = avg * 0.995 + out[i] * 0.005;
+    out[i] = (out[i] - avg) * amp * fade(i, n, 150);
+  }
+
+  // Add subtle bubbling — sparse higher-freq pops.
+  const rng2 = prng(456);
+  for (let i = 0; i < n; i += Math.floor(SAMPLE_RATE * 0.02)) {
+    if (rng2() > 0.4) {
+      const freq = 800 + rng2() * 600;
+      const len = Math.floor(SAMPLE_RATE * 0.008);
+      for (let j = 0; j < len && i + j < n; j++) {
+        out[i + j] += Math.sin(2 * Math.PI * freq * (j / SAMPLE_RATE)) * amp * 0.15 * Math.exp(-j / (len * 0.3));
+      }
+    }
+  }
+
+  return encodeWav(out);
+}
+
+/** Hum — rich harmonic drone (machinery, power grid). */
+function generateHum(duration: number, amp: number, baseFreq: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const harmonics = [1, 2, 3, 4, 5, 6];
+  const harmonicAmps = [1, 0.5, 0.35, 0.2, 0.12, 0.08];
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    let sample = 0;
+    for (let h = 0; h < harmonics.length; h++) {
+      sample += Math.sin(2 * Math.PI * baseFreq * harmonics[h] * t) * harmonicAmps[h];
+    }
+    // Subtle amplitude wobble.
+    const wobble = 1 + 0.08 * Math.sin(2 * Math.PI * 1.5 * t);
+    out[i] = sample * amp * wobble * fade(i, n, 80) / harmonics.length;
+  }
+
+  return encodeWav(out);
+}
+
+/** Sweep — frequency glide (door slide, alarm siren). */
+function generateSweep(startFreq: number, endFreq: number, duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    const progress = i / n;
+    const freq = startFreq + (endFreq - startFreq) * progress;
+    out[i] = Math.sin(2 * Math.PI * freq * t) * amp * fade(i, n, 15);
+  }
+
+  return encodeWav(out);
+}
+
+/** Chime — bell-like decaying tone with inharmonic partials. */
+function generateChime(freq: number, duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const partials = [1, 2.76, 5.4, 8.93];
+  const partialAmps = [1, 0.6, 0.3, 0.15];
+  const decays = [1.2, 0.8, 0.5, 0.3];
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    let sample = 0;
+    for (let p = 0; p < partials.length; p++) {
+      sample += Math.sin(2 * Math.PI * freq * partials[p] * t) * partialAmps[p] * Math.exp(-t / decays[p]);
+    }
+    out[i] = sample * amp * fade(i, n, 2) / partials.length;
+  }
+
+  return encodeWav(out);
+}
+
+/** Impact — short thud or click (footstep, UI click). */
+function generateImpact(freq: number, duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(99);
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    const env = Math.exp(-t / (duration * 0.2));
+    const tone = Math.sin(2 * Math.PI * freq * t) * 0.6;
+    const click = noise() * 0.4;
+    out[i] = (tone + click) * amp * env;
+  }
+
+  return encodeWav(out);
+}
+
+/** Explosion — noise burst with deep rumble tail. */
+function generateExplosion(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(333);
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    // Initial noise burst.
+    const burst = noise() * Math.exp(-t / 0.05);
+    // Deep rumble.
+    const rumble = Math.sin(2 * Math.PI * 35 * t) * Math.exp(-t / 0.4) * 0.6;
+    const rumble2 = Math.sin(2 * Math.PI * 55 * t) * Math.exp(-t / 0.3) * 0.3;
+    out[i] = (burst + rumble + rumble2) * amp * fade(i, n, 2);
+  }
+
+  // Low-pass the burst portion.
+  for (let i = 1; i < n; i++) {
+    out[i] = out[i] * 0.5 + out[i - 1] * 0.5;
+  }
+
+  return encodeWav(out);
+}
+
+/** Pickup — ascending chime arpeggio. */
+function generatePickup(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const notes = [523, 659, 784, 1047]; // C5, E5, G5, C6
+  const noteLen = Math.floor(n / notes.length);
+
+  for (let ni = 0; ni < notes.length; ni++) {
+    const start = ni * noteLen;
+    for (let i = 0; i < noteLen && start + i < n; i++) {
+      const t = i / SAMPLE_RATE;
+      const env = Math.exp(-t / (duration * 0.6));
+      out[start + i] += Math.sin(2 * Math.PI * notes[ni] * t) * amp * env * fade(i, noteLen, 3);
+    }
+  }
+
+  return encodeWav(out);
 }

--- a/apps/three-vanilla-playground/package.json
+++ b/apps/three-vanilla-playground/package.json
@@ -14,6 +14,7 @@
     "@dimforge/rapier3d-compat": "^0.19.2",
     "@ggez/gameplay-runtime": "workspace:*",
     "@ggez/render-pipeline": "workspace:*",
+    "@ggez/runtime-audio": "workspace:*",
     "@ggez/runtime-physics-rapier": "workspace:*",
     "@ggez/shared": "workspace:*",
     "@ggez/three-runtime": "workspace:*",

--- a/apps/three-vanilla-playground/src/app.ts
+++ b/apps/three-vanilla-playground/src/app.ts
@@ -1,4 +1,5 @@
 import { createGameplayRuntime, createGameplayRuntimeSceneFromRuntimeScene } from "@ggez/gameplay-runtime";
+import { createAudioManager, type AudioManager } from "@ggez/runtime-audio";
 import { normalizeSceneSettings } from "@ggez/shared";
 import {
   createWebHammerBundleAssetResolver,
@@ -14,6 +15,7 @@ import { createSampleScene, resolveSampleAssetPath } from "./sample-scene";
 import type { AssetPathResolver, EnabledSystemKey, EnabledSystemsState, PlaybackPhysicsState, StageStats } from "./types";
 
 const DEFAULT_SYSTEMS: EnabledSystemsState = {
+  audio: true,
   mover: true,
   openable: true,
   pathMover: true,
@@ -26,7 +28,8 @@ const SYSTEM_OPTIONS: Array<{ key: EnabledSystemKey; label: string }> = [
   { key: "sequence", label: "Sequence" },
   { key: "openable", label: "Openable" },
   { key: "mover", label: "Mover" },
-  { key: "pathMover", label: "Path Mover" }
+  { key: "pathMover", label: "Path Mover" },
+  { key: "audio", label: "Audio" }
 ];
 
 export function createRuntimePlaygroundApp(root: HTMLElement) {
@@ -40,6 +43,7 @@ class RuntimePlaygroundApp {
   private readonly root: HTMLElement;
   private readonly sceneController: PlaybackSceneController;
 
+  private audioManager?: AudioManager;
   private bundleResolver?: ReturnType<typeof createWebHammerBundleAssetResolver>;
   private drawerOpen = false;
   private enabledSystems: EnabledSystemsState = { ...DEFAULT_SYSTEMS };
@@ -55,11 +59,20 @@ class RuntimePlaygroundApp {
   constructor(root: HTMLElement) {
     this.root = root;
     this.refs = createShell(root);
-    this.fileInput.accept = ".zip,.json";
+    this.fileInput.accept = ".zip,.json,.whmap";
     this.fileInput.className = "hidden";
     this.fileInput.type = "file";
     this.fileInput.addEventListener("change", this.handleFileInput);
     this.refs.topBar.append(this.fileInput);
+
+    // Resume AudioContext on first user gesture (browsers require this).
+    const resumeAudio = () => {
+      void this.audioManager?.resume();
+      window.removeEventListener("pointerdown", resumeAudio);
+      window.removeEventListener("keydown", resumeAudio);
+    };
+    window.addEventListener("pointerdown", resumeAudio, { once: true });
+    window.addEventListener("keydown", resumeAudio, { once: true });
     this.sceneController = new PlaybackSceneController(this.refs.stage, {
       host: this.host,
       onError: (message) => {
@@ -96,19 +109,60 @@ class RuntimePlaygroundApp {
 
   private async rebuildRuntime() {
     this.gameplayRuntime?.dispose();
+    this.audioManager?.dispose();
+    this.audioManager = undefined;
+
     const renderScene = createPlaybackRenderScene(this.scene);
     const sceneSettings = normalizeSceneSettings(this.scene.settings);
+    const resolveAssetPath = this.resolveAssetPath;
     const gameplayRuntime = createGameplayRuntime({
       host: this.host.host,
       scene: createGameplayRuntimeSceneFromRuntimeScene(this.scene),
       systems: createPlaybackGameplaySystems(this.scene, this.enabledSystems)
     });
 
+    // Wire AudioManager to gameplay audio events.
+    const audioManager = createAudioManager({
+      clipResolver: async (clipId) => {
+        const url = await Promise.resolve(resolveAssetPath(clipId));
+        const response = await fetch(url);
+        return response.arrayBuffer();
+      }
+    });
+    this.audioManager = audioManager;
+
     this.host.reset();
     this.runtimeEvents = [];
     gameplayRuntime.onEvent((event) => {
       this.runtimeEvents = [`${event.event}${event.targetId ? ` -> ${event.targetId}` : ""}`, ...this.runtimeEvents].slice(0, 12);
       this.render();
+
+      if (event.event === "audio.play") {
+        const p = event.payload as Record<string, unknown> | undefined;
+        if (p?.clip && typeof p.clip === "string") {
+          void audioManager.play({
+            channel: (p.channel as "sfx" | "music" | "ambient" | "ui" | "voice") ?? "sfx",
+            clip: p.clip as string,
+            distanceModel: (p.distanceModel as "inverse" | "linear" | "exponential") ?? "inverse",
+            id: p.hookId as string | undefined,
+            loop: p.loop === true,
+            maxDistance: typeof p.maxDistance === "number" ? p.maxDistance : 10000,
+            pitch: typeof p.pitch === "number" ? p.pitch : 1,
+            position: Array.isArray(p.position) ? { x: p.position[0], y: p.position[1], z: p.position[2] } : undefined,
+            refDistance: typeof p.refDistance === "number" ? p.refDistance : 1,
+            rolloffFactor: typeof p.rolloffFactor === "number" ? p.rolloffFactor : 1,
+            spatial: p.spatial === true,
+            volume: typeof p.volume === "number" ? p.volume : 1
+          });
+        }
+      }
+
+      if (event.event === "audio.stop") {
+        const p = event.payload as Record<string, unknown> | undefined;
+        if (p?.hookId && typeof p.hookId === "string") {
+          audioManager.stop(p.hookId);
+        }
+      }
     });
     gameplayRuntime.start();
     this.gameplayRuntime = gameplayRuntime;
@@ -146,7 +200,7 @@ class RuntimePlaygroundApp {
         const text = await file.text();
         this.bundleResolver?.dispose();
         this.bundleResolver = undefined;
-        nextScene = parseWebHammerEngineScene(text);
+        nextScene = parseSceneText(text);
       }
 
       this.scene = nextScene;
@@ -444,4 +498,23 @@ function escapeHtml(value: string) {
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;");
+}
+
+/** Parse scene text — handles both runtime format and .whmap editor format. */
+function parseSceneText(text: string): WebHammerEngineScene {
+  const parsed = JSON.parse(text);
+
+  // .whmap editor format: { format: "whmap", scene: { ... } }
+  if (parsed?.format === "whmap" && parsed.scene) {
+    const scene = parsed.scene;
+    // Inject runtime metadata so parseWebHammerEngineScene accepts it.
+    scene.metadata = {
+      exportedAt: new Date().toISOString(),
+      format: "web-hammer-engine",
+      version: 6
+    };
+    return parseWebHammerEngineScene(JSON.stringify(scene));
+  }
+
+  return parseWebHammerEngineScene(text);
 }

--- a/apps/three-vanilla-playground/src/gameplay-systems.ts
+++ b/apps/three-vanilla-playground/src/gameplay-systems.ts
@@ -1,4 +1,5 @@
 import {
+  createAudioSystemDefinition,
   createMoverSystemDefinition,
   createOpenableSystemDefinition,
   createPathMoverSystemDefinition,
@@ -10,6 +11,7 @@ import {
 import type { WebHammerEngineScene } from "@ggez/three-runtime";
 
 export type PlaybackGameplaySystemsState = {
+  audio: boolean;
   mover: boolean;
   openable: boolean;
   pathMover: boolean;
@@ -41,6 +43,10 @@ export function createPlaybackGameplaySystems(
 
   if (enabledSystems.pathMover) {
     systems.push(createPathMoverSystemDefinition(createScenePathResolver(scene.settings.paths ?? [])));
+  }
+
+  if (enabledSystems.audio) {
+    systems.push(createAudioSystemDefinition());
   }
 
   return systems;

--- a/apps/three-vanilla-playground/src/sample-scene.ts
+++ b/apps/three-vanilla-playground/src/sample-scene.ts
@@ -80,6 +80,20 @@ export function createSampleScene(): WebHammerEngineScene {
           uvScale: { x: 4, y: 4 }
         },
         geometry: geometryFromPrimitive(new BoxGeometry(16, 0.8, 16), floorMaterial),
+        hooks: [
+          {
+            config: {
+              autoPlay: true,
+              clip: "sample:wind",
+              loop: true,
+              spatial: false,
+              volume: 0.12
+            },
+            enabled: true,
+            id: "hook:sample:floor:wind",
+            type: "audio_emitter"
+          }
+        ],
         id: "node:sample:floor",
         kind: "primitive",
         name: "Floor",
@@ -146,6 +160,23 @@ export function createSampleScene(): WebHammerEngineScene {
             enabled: true,
             id: "hook:sample:spire:tags",
             type: "tags"
+          },
+          {
+            config: {
+              autoPlay: true,
+              clip: "sample:machinery",
+              distanceModel: "inverse",
+              loop: true,
+              maxDistance: 25,
+              pitch: 1,
+              refDistance: 2,
+              rolloffFactor: 1.5,
+              spatial: true,
+              volume: 0.3
+            },
+            enabled: true,
+            id: "hook:sample:spire:audio",
+            type: "audio_emitter"
           }
         ],
         id: "node:sample:spire-group",
@@ -219,6 +250,22 @@ export function createSampleScene(): WebHammerEngineScene {
             enabled: true,
             id: "hook:sample:door:mover",
             type: "mover"
+          },
+          {
+            config: {
+              clip: "sample:door-slide",
+              distanceModel: "inverse",
+              maxDistance: 20,
+              pitch: 1,
+              refDistance: 1,
+              rolloffFactor: 2,
+              spatial: true,
+              triggerEvent: "open.started",
+              volume: 0.8
+            },
+            enabled: true,
+            id: "hook:sample:door:audio",
+            type: "audio_emitter"
           }
         ],
         id: "node:sample:door-root",
@@ -275,6 +322,22 @@ export function createSampleScene(): WebHammerEngineScene {
             enabled: true,
             id: "hook:sample:platform:trigger",
             type: "trigger_volume"
+          },
+          {
+            config: {
+              clip: "sample:chime",
+              distanceModel: "inverse",
+              maxDistance: 30,
+              pitch: 1,
+              refDistance: 2,
+              rolloffFactor: 1,
+              spatial: true,
+              triggerEvent: "trigger.enter",
+              volume: 0.5
+            },
+            enabled: true,
+            id: "hook:sample:platform:audio",
+            type: "audio_emitter"
           },
           {
             config: {
@@ -431,12 +494,43 @@ export function createSampleScene(): WebHammerEngineScene {
   };
 }
 
+const sampleAudioCache = new Map<string, string>();
+
 export async function resolveSampleAssetPath(path: string) {
   if (path === SAMPLE_MODEL_PATH) {
     return createSampleGltfDataUrl();
   }
 
+  if (path.startsWith("sample:")) {
+    const cached = sampleAudioCache.get(path);
+    if (cached) return cached;
+
+    const url = generateSampleAudio(path);
+    if (url) {
+      sampleAudioCache.set(path, url);
+      return url;
+    }
+  }
+
   return path;
+}
+
+function generateSampleAudio(clipId: string): string | undefined {
+  switch (clipId) {
+    case "sample:wind":          return generateWind(4, 0.25);
+    case "sample:rain":          return generateRain(3, 0.2);
+    case "sample:water-stream":  return generateWaterStream(3, 0.2);
+    case "sample:ambient-hum":   return generateHum(2, 0.15, 90);
+    case "sample:machinery":     return generateHum(3, 0.2, 60);
+    case "sample:door-slide":    return generateSweep(140, 80, 0.6, 0.3);
+    case "sample:chime":         return generateChime(880, 1.2, 0.35);
+    case "sample:footstep":      return generateImpact(60, 0.08, 0.4);
+    case "sample:click":         return generateImpact(2000, 0.025, 0.3);
+    case "sample:alarm":         return generateSweep(600, 1200, 1.5, 0.2);
+    case "sample:explosion":     return generateExplosion(1.2, 0.4);
+    case "sample:pickup":        return generatePickup(0.4, 0.3);
+    default:                     return undefined;
+  }
 }
 
 function geometryFromPrimitive(geometry: BufferGeometry, material: WebHammerExportMaterial) {
@@ -621,4 +715,263 @@ function toBase64(bytes: Uint8Array) {
     binary += String.fromCharCode(value);
   });
   return btoa(binary);
+}
+
+// ---------------------------------------------------------------------------
+//  Procedural audio generators — all produce mono 16-bit WAV data URLs.
+// ---------------------------------------------------------------------------
+
+const SAMPLE_RATE = 22050;
+
+function encodeWav(samples: Float32Array): string {
+  const numSamples = samples.length;
+  const dataSize = numSamples * 2;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  writeString(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeString(view, 8, "WAVE");
+  writeString(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, SAMPLE_RATE, true);
+  view.setUint32(28, SAMPLE_RATE * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeString(view, 36, "data");
+  view.setUint32(40, dataSize, true);
+
+  for (let i = 0; i < numSamples; i++) {
+    view.setInt16(44 + i * 2, Math.max(-32768, Math.min(32767, Math.round(samples[i] * 32767))), true);
+  }
+
+  return `data:audio/wav;base64,${toBase64(new Uint8Array(buffer))}`;
+}
+
+function writeString(view: DataView, offset: number, value: string) {
+  for (let i = 0; i < value.length; i++) {
+    view.setUint8(offset + i, value.charCodeAt(i));
+  }
+}
+
+function fade(i: number, total: number, fadeMs = 20): number {
+  const fadeSamples = (SAMPLE_RATE * fadeMs) / 1000;
+  return Math.min(1, i / fadeSamples) * Math.min(1, (total - i) / fadeSamples);
+}
+
+// Seeded PRNG for deterministic noise.
+function prng(seed: number) {
+  let s = seed | 0;
+  return () => {
+    s = (s * 1103515245 + 12345) & 0x7fffffff;
+    return (s / 0x7fffffff) * 2 - 1;
+  };
+}
+
+/** Wind — layered filtered noise with slow amplitude modulation. */
+function generateWind(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(42);
+
+  // Generate raw noise then low-pass filter by averaging.
+  const raw = new Float32Array(n);
+  for (let i = 0; i < n; i++) raw[i] = noise();
+
+  // Simple moving-average low-pass (window = 60 ≈ ~370 Hz cutoff).
+  const window = 60;
+  let sum = 0;
+  for (let i = 0; i < window && i < n; i++) sum += raw[i];
+  for (let i = 0; i < n; i++) {
+    if (i >= window) sum -= raw[i - window];
+    if (i + window < n) sum += raw[i + window];
+    const filtered = sum / window;
+    // Slow modulation at ~0.3 Hz for gusts.
+    const gust = 0.5 + 0.5 * Math.sin(2 * Math.PI * 0.3 * (i / SAMPLE_RATE));
+    out[i] = filtered * amp * gust * fade(i, n, 200);
+  }
+
+  return encodeWav(out);
+}
+
+/** Rain — sparse random drops with short exponential decay. */
+function generateRain(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const rng = prng(77);
+  const dropInterval = Math.floor(SAMPLE_RATE * 0.012);
+  const decaySamples = Math.floor(SAMPLE_RATE * 0.004);
+
+  for (let i = 0; i < n; i += dropInterval) {
+    if (rng() > -0.3) {
+      const strength = 0.5 + 0.5 * Math.abs(rng());
+      for (let j = 0; j < decaySamples && i + j < n; j++) {
+        out[i + j] += rng() * amp * strength * Math.exp(-j / (decaySamples * 0.25));
+      }
+    }
+  }
+
+  // Soft low-pass.
+  for (let i = 1; i < n; i++) {
+    out[i] = out[i] * 0.6 + out[i - 1] * 0.4;
+  }
+
+  for (let i = 0; i < n; i++) out[i] *= fade(i, n, 100);
+  return encodeWav(out);
+}
+
+/** Water stream — denser noise with bandpass character. */
+function generateWaterStream(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(123);
+
+  for (let i = 0; i < n; i++) {
+    out[i] = noise();
+  }
+
+  // Bandpass: low-pass then high-pass.
+  for (let pass = 0; pass < 3; pass++) {
+    for (let i = 1; i < n; i++) {
+      out[i] = out[i] * 0.35 + out[i - 1] * 0.65;
+    }
+  }
+  // High-pass (subtract running average).
+  let avg = 0;
+  for (let i = 0; i < n; i++) {
+    avg = avg * 0.995 + out[i] * 0.005;
+    out[i] = (out[i] - avg) * amp * fade(i, n, 150);
+  }
+
+  // Add subtle bubbling — sparse higher-freq pops.
+  const rng2 = prng(456);
+  for (let i = 0; i < n; i += Math.floor(SAMPLE_RATE * 0.02)) {
+    if (rng2() > 0.4) {
+      const freq = 800 + rng2() * 600;
+      const len = Math.floor(SAMPLE_RATE * 0.008);
+      for (let j = 0; j < len && i + j < n; j++) {
+        out[i + j] += Math.sin(2 * Math.PI * freq * (j / SAMPLE_RATE)) * amp * 0.15 * Math.exp(-j / (len * 0.3));
+      }
+    }
+  }
+
+  return encodeWav(out);
+}
+
+/** Hum — rich harmonic drone (machinery, power grid). */
+function generateHum(duration: number, amp: number, baseFreq: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const harmonics = [1, 2, 3, 4, 5, 6];
+  const harmonicAmps = [1, 0.5, 0.35, 0.2, 0.12, 0.08];
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    let sample = 0;
+    for (let h = 0; h < harmonics.length; h++) {
+      sample += Math.sin(2 * Math.PI * baseFreq * harmonics[h] * t) * harmonicAmps[h];
+    }
+    // Subtle amplitude wobble.
+    const wobble = 1 + 0.08 * Math.sin(2 * Math.PI * 1.5 * t);
+    out[i] = sample * amp * wobble * fade(i, n, 80) / harmonics.length;
+  }
+
+  return encodeWav(out);
+}
+
+/** Sweep — frequency glide (door slide, alarm siren). */
+function generateSweep(startFreq: number, endFreq: number, duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    const progress = i / n;
+    const freq = startFreq + (endFreq - startFreq) * progress;
+    out[i] = Math.sin(2 * Math.PI * freq * t) * amp * fade(i, n, 15);
+  }
+
+  return encodeWav(out);
+}
+
+/** Chime — bell-like decaying tone with inharmonic partials. */
+function generateChime(freq: number, duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const partials = [1, 2.76, 5.4, 8.93];
+  const partialAmps = [1, 0.6, 0.3, 0.15];
+  const decays = [1.2, 0.8, 0.5, 0.3];
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    let sample = 0;
+    for (let p = 0; p < partials.length; p++) {
+      sample += Math.sin(2 * Math.PI * freq * partials[p] * t) * partialAmps[p] * Math.exp(-t / decays[p]);
+    }
+    out[i] = sample * amp * fade(i, n, 2) / partials.length;
+  }
+
+  return encodeWav(out);
+}
+
+/** Impact — short thud or click (footstep, UI click). */
+function generateImpact(freq: number, duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(99);
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    const env = Math.exp(-t / (duration * 0.2));
+    const tone = Math.sin(2 * Math.PI * freq * t) * 0.6;
+    const click = noise() * 0.4;
+    out[i] = (tone + click) * amp * env;
+  }
+
+  return encodeWav(out);
+}
+
+/** Explosion — noise burst with deep rumble tail. */
+function generateExplosion(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(333);
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    // Initial noise burst.
+    const burst = noise() * Math.exp(-t / 0.05);
+    // Deep rumble.
+    const rumble = Math.sin(2 * Math.PI * 35 * t) * Math.exp(-t / 0.4) * 0.6;
+    const rumble2 = Math.sin(2 * Math.PI * 55 * t) * Math.exp(-t / 0.3) * 0.3;
+    out[i] = (burst + rumble + rumble2) * amp * fade(i, n, 2);
+  }
+
+  // Low-pass the burst portion.
+  for (let i = 1; i < n; i++) {
+    out[i] = out[i] * 0.5 + out[i - 1] * 0.5;
+  }
+
+  return encodeWav(out);
+}
+
+/** Pickup — ascending chime arpeggio. */
+function generatePickup(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const notes = [523, 659, 784, 1047]; // C5, E5, G5, C6
+  const noteLen = Math.floor(n / notes.length);
+
+  for (let ni = 0; ni < notes.length; ni++) {
+    const start = ni * noteLen;
+    for (let i = 0; i < noteLen && start + i < n; i++) {
+      const t = i / SAMPLE_RATE;
+      const env = Math.exp(-t / (duration * 0.6));
+      out[start + i] += Math.sin(2 * Math.PI * notes[ni] * t) * amp * env * fade(i, noteLen, 3);
+    }
+  }
+
+  return encodeWav(out);
 }

--- a/apps/three-vanilla-playground/src/types.ts
+++ b/apps/three-vanilla-playground/src/types.ts
@@ -16,6 +16,7 @@ export type PlayerActor = {
 };
 
 export type EnabledSystemsState = {
+  audio: boolean;
   mover: boolean;
   openable: boolean;
   pathMover: boolean;

--- a/packages/gameplay-runtime/src/systems.ts
+++ b/packages/gameplay-runtime/src/systems.ts
@@ -104,7 +104,7 @@ export const GAMEPLAY_SYSTEM_BLUEPRINTS: GameplaySystemBlueprint[] = [
     description: "Routes gameplay events to audio playback.",
     hookTypes: ["audio_emitter"],
     id: "audio",
-    implemented: false,
+    implemented: true,
     label: "AudioSystem"
   },
   {
@@ -992,4 +992,105 @@ function wrapProgress(value: number) {
   }
 
   return value % 1;
+}
+
+export function createAudioSystemDefinition(): GameplayRuntimeSystemDefinition {
+  return {
+    description: "Routes gameplay events to audio playback via audio_emitter hooks.",
+    hookTypes: ["audio_emitter"],
+    id: "audio",
+    label: "AudioSystem",
+    create(context) {
+      const unsubscribes: Array<() => void> = [];
+
+      return {
+        start() {
+          context.getHookTargetsByType("audio_emitter")
+            .filter((target) => target.hook.enabled !== false)
+            .forEach((target) => {
+              const autoPlay = readBoolean(target.hook.config.autoPlay, false);
+
+              if (autoPlay) {
+                emitAudioPlay(context, target);
+              }
+
+              const triggerEvent = readString(target.hook.config.triggerEvent, "");
+
+              if (triggerEvent) {
+                const unsub = context.eventBus.subscribe(
+                  { event: triggerEvent, targetId: target.targetId },
+                  () => {
+                    if (target.hook.enabled === false) {
+                      return;
+                    }
+
+                    emitAudioPlay(context, target);
+                  }
+                );
+
+                unsubscribes.push(unsub);
+              }
+
+              const stopEvent = readString(target.hook.config.stopEvent, "");
+
+              if (stopEvent) {
+                const unsub = context.eventBus.subscribe(
+                  { event: stopEvent, targetId: target.targetId },
+                  () => {
+                    context.emitFromHookTarget(target, "audio.stop", {
+                      hookId: target.hook.id
+                    });
+                  }
+                );
+
+                unsubscribes.push(unsub);
+              }
+            });
+
+          // Global audio control events.
+          unsubscribes.push(
+            context.eventBus.subscribe({ event: "audio.stop_all" }, () => {
+              context.getHookTargetsByType("audio_emitter").forEach((target) => {
+                context.emitFromHookTarget(target, "audio.stop", {
+                  hookId: target.hook.id
+                });
+              });
+            })
+          );
+        },
+        stop() {
+          unsubscribes.forEach((unsub) => unsub());
+          unsubscribes.length = 0;
+        }
+      };
+    }
+  };
+}
+
+function emitAudioPlay(
+  context: GameplayRuntimeSystemContext,
+  target: GameplayHookTarget
+) {
+  const clip = readString(target.hook.config.clip, "");
+
+  if (!clip) {
+    return;
+  }
+
+  const worldTransform = context.getTargetWorldTransform(target.targetId);
+
+  context.emitFromHookTarget(target, "audio.play", {
+    channel: readString(target.hook.config.channel, "sfx"),
+    clip,
+    distanceModel: readString(target.hook.config.distanceModel, "inverse"),
+    hookId: target.hook.id,
+    loop: readBoolean(target.hook.config.loop, false),
+    maxDistance: readNumber(target.hook.config.maxDistance, 10000),
+    pitch: readNumber(target.hook.config.pitch, 1),
+    position: worldTransform ? [worldTransform.position.x, worldTransform.position.y, worldTransform.position.z] : null,
+    refDistance: readNumber(target.hook.config.refDistance, 1),
+    rolloffFactor: readNumber(target.hook.config.rolloffFactor, 1),
+    spatial: readBoolean(target.hook.config.spatial, false),
+    volume: readNumber(target.hook.config.volume, 1)
+  });
 }

--- a/packages/runtime-audio/package.json
+++ b/packages/runtime-audio/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@ggez/runtime-audio",
+  "version": "0.1.1",
+  "description": "Web Audio API adapter for Web Hammer runtime scenes with 3D spatial audio support.",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup --config ../../scripts/tsup.package.config.mjs",
+    "prepublishOnly": "bun run build"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vibe-stack/trident.git",
+    "directory": "packages/runtime-audio"
+  },
+  "bugs": {
+    "url": "https://github.com/vibe-stack/trident/issues"
+  },
+  "homepage": "https://github.com/vibe-stack/trident/tree/main/packages/runtime-audio",
+  "dependencies": {
+    "@ggez/runtime-format": "workspace:*",
+    "@ggez/shared": "workspace:*"
+  }
+}

--- a/packages/runtime-audio/src/audio-manager.ts
+++ b/packages/runtime-audio/src/audio-manager.ts
@@ -1,0 +1,436 @@
+import type { Vec3 } from "@ggez/shared";
+import type {
+  AudioChannel,
+  AudioClipResolver,
+  AudioManagerOptions,
+  AudioPlayOptions,
+  AudioSourceHandle,
+  AudioSourceState
+} from "./types";
+
+const CHANNELS: AudioChannel[] = ["sfx", "music", "ambient", "ui", "voice"];
+const DEFAULT_CHANNEL: AudioChannel = "sfx";
+
+/**
+ * Manages Web Audio API context, clip loading/caching, playback, 3D spatial audio,
+ * and a built-in mixer with independent channel volumes (sfx, music, ambient, ui, voice).
+ *
+ * Audio graph:  source → gainNode → [pannerNode] → channelGain → masterGain → destination
+ */
+export class AudioManager {
+  private readonly context: AudioContext;
+  private readonly masterGain: GainNode;
+  private readonly channelGains: Record<AudioChannel, GainNode>;
+  private readonly clipResolver: AudioClipResolver;
+  private readonly bufferCache = new Map<string, AudioBuffer>();
+  private readonly pendingLoads = new Map<string, Promise<AudioBuffer>>();
+  private readonly activeSources = new Map<string, AudioSourceState>();
+  private sourceSequence = 0;
+
+  constructor(options: AudioManagerOptions) {
+    this.clipResolver = options.clipResolver;
+    this.context = new AudioContext();
+    this.masterGain = this.context.createGain();
+    this.masterGain.gain.value = Math.max(0, Math.min(1, options.masterVolume ?? 1));
+    this.masterGain.connect(this.context.destination);
+
+    // Create one GainNode per channel, all feeding into masterGain.
+    this.channelGains = {} as Record<AudioChannel, GainNode>;
+    for (const channel of CHANNELS) {
+      const gain = this.context.createGain();
+      gain.gain.value = 1;
+      gain.connect(this.masterGain);
+      this.channelGains[channel] = gain;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Context lifecycle
+  // ---------------------------------------------------------------------------
+
+  /** Resume the AudioContext after a user gesture (required by browsers). */
+  async resume() {
+    if (this.context.state === "suspended") {
+      await this.context.resume();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Master volume
+  // ---------------------------------------------------------------------------
+
+  /** Master volume (0–1). Affects all channels. */
+  get masterVolume() {
+    return this.masterGain.gain.value;
+  }
+
+  set masterVolume(value: number) {
+    this.masterGain.gain.value = Math.max(0, Math.min(1, value));
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Channel mixer
+  // ---------------------------------------------------------------------------
+
+  /** Get the volume of a mixer channel (0–1). */
+  getChannelVolume(channel: AudioChannel): number {
+    return this.channelGains[channel]?.gain.value ?? 1;
+  }
+
+  /** Set the volume of a mixer channel (0–1). */
+  setChannelVolume(channel: AudioChannel, volume: number) {
+    const gain = this.channelGains[channel];
+    if (gain) {
+      gain.gain.value = Math.max(0, Math.min(1, volume));
+    }
+  }
+
+  /** Get all channel names. */
+  get channels(): readonly AudioChannel[] {
+    return CHANNELS;
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Listener (spatial audio)
+  // ---------------------------------------------------------------------------
+
+  /** Update the listener position and optional orientation for spatial audio. */
+  setListenerPosition(position: Vec3, forward?: Vec3, up?: Vec3) {
+    const listener = this.context.listener;
+
+    if (listener.positionX) {
+      listener.positionX.value = position.x;
+      listener.positionY.value = position.y;
+      listener.positionZ.value = position.z;
+    } else {
+      listener.setPosition(position.x, position.y, position.z);
+    }
+
+    if (forward && up) {
+      if (listener.forwardX) {
+        listener.forwardX.value = forward.x;
+        listener.forwardY.value = forward.y;
+        listener.forwardZ.value = forward.z;
+        listener.upX.value = up.x;
+        listener.upY.value = up.y;
+        listener.upZ.value = up.z;
+      } else {
+        listener.setOrientation(forward.x, forward.y, forward.z, up.x, up.y, up.z);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Clip loading
+  // ---------------------------------------------------------------------------
+
+  /** Load and decode a clip into the buffer cache. Deduplicates concurrent loads. */
+  async loadClip(clipId: string): Promise<AudioBuffer> {
+    const cached = this.bufferCache.get(clipId);
+    if (cached) return cached;
+
+    // Deduplicate in-flight loads for the same clip.
+    const pending = this.pendingLoads.get(clipId);
+    if (pending) return pending;
+
+    const loadPromise = (async () => {
+      try {
+        const raw = await this.clipResolver(clipId);
+        const buffer = await this.context.decodeAudioData(raw.slice(0));
+        this.bufferCache.set(clipId, buffer);
+        return buffer;
+      } catch (error) {
+        throw new Error(
+          `AudioManager: failed to load clip "${clipId}": ${error instanceof Error ? error.message : String(error)}`
+        );
+      } finally {
+        this.pendingLoads.delete(clipId);
+      }
+    })();
+
+    this.pendingLoads.set(clipId, loadPromise);
+    return loadPromise;
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Playback
+  // ---------------------------------------------------------------------------
+
+  /** Play a clip and return a handle to control the source. */
+  async play(options: AudioPlayOptions): Promise<AudioSourceHandle> {
+    await this.resume();
+
+    const buffer = await this.loadClip(options.clip);
+    const id = options.id ?? `audio:${this.sourceSequence += 1}`;
+    const channel = options.channel ?? DEFAULT_CHANNEL;
+
+    // Stop any existing source with the same id.
+    this.stopById(id);
+
+    const channelGain = this.channelGains[channel] ?? this.channelGains.sfx;
+    const gainNode = this.context.createGain();
+    gainNode.gain.value = Math.max(0, Math.min(1, options.volume ?? 1));
+
+    let pannerNode: PannerNode | undefined;
+
+    if (options.spatial) {
+      pannerNode = this.context.createPanner();
+      pannerNode.panningModel = "HRTF";
+      pannerNode.distanceModel = options.distanceModel ?? "inverse";
+      pannerNode.refDistance = options.refDistance ?? 1;
+      pannerNode.maxDistance = options.maxDistance ?? 10000;
+      pannerNode.rolloffFactor = options.rolloffFactor ?? 1;
+
+      if (options.position) {
+        pannerNode.positionX.value = options.position.x;
+        pannerNode.positionY.value = options.position.y;
+        pannerNode.positionZ.value = options.position.z;
+      }
+
+      gainNode.connect(pannerNode);
+      pannerNode.connect(channelGain);
+    } else {
+      gainNode.connect(channelGain);
+    }
+
+    const source = this.context.createBufferSource();
+    source.buffer = buffer;
+    source.loop = options.loop ?? false;
+    source.playbackRate.value = options.pitch ?? 1;
+    source.connect(gainNode);
+    source.start(0);
+
+    const state: AudioSourceState = {
+      channel,
+      clipId: options.clip,
+      gainNode,
+      id,
+      loop: options.loop ?? false,
+      pannerNode,
+      paused: false,
+      pausedAt: 0,
+      pitch: options.pitch ?? 1,
+      source,
+      spatial: options.spatial ?? false,
+      startedAt: this.context.currentTime
+    };
+
+    source.onended = () => {
+      if (!state.paused) {
+        this.cleanupSource(id);
+      }
+    };
+
+    this.activeSources.set(id, state);
+
+    return this.createHandle(id);
+  }
+
+  /** Play a one-shot clip that cannot be stopped or paused. Fire-and-forget. */
+  async playOneShot(clip: string, volume = 1, pitch = 1, channel: AudioChannel = "sfx") {
+    await this.resume();
+
+    const buffer = await this.loadClip(clip);
+    const channelGain = this.channelGains[channel] ?? this.channelGains.sfx;
+    const gainNode = this.context.createGain();
+    gainNode.gain.value = Math.max(0, Math.min(1, volume));
+    gainNode.connect(channelGain);
+
+    const source = this.context.createBufferSource();
+    source.buffer = buffer;
+    source.playbackRate.value = pitch;
+    source.connect(gainNode);
+    source.onended = () => {
+      gainNode.disconnect();
+    };
+    source.start(0);
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Source control
+  // ---------------------------------------------------------------------------
+
+  /** Get a handle for an active source by its id. */
+  getSource(id: string): AudioSourceHandle | undefined {
+    if (!this.activeSources.has(id)) {
+      return undefined;
+    }
+
+    return this.createHandle(id);
+  }
+
+  /** Stop a source by id. */
+  stop(id: string) {
+    this.stopById(id);
+  }
+
+  /** Stop all active sources. */
+  stopAll() {
+    for (const id of [...this.activeSources.keys()]) {
+      this.stopById(id);
+    }
+  }
+
+  /** Stop all active sources on a specific channel. */
+  stopChannel(channel: AudioChannel) {
+    for (const [id, state] of this.activeSources) {
+      if (state.channel === channel) {
+        this.stopById(id);
+      }
+    }
+  }
+
+  /** Pause a source by id. */
+  pause(id: string) {
+    const state = this.activeSources.get(id);
+
+    if (!state || state.paused || !state.source) {
+      return;
+    }
+
+    state.pausedAt = this.context.currentTime - state.startedAt;
+    state.paused = true;
+    state.source.onended = null;
+    state.source.stop();
+    state.source.disconnect();
+    state.source = undefined;
+  }
+
+  /** Resume a paused source by id. */
+  async resumeSource(id: string) {
+    const state = this.activeSources.get(id);
+
+    if (!state || !state.paused) {
+      return;
+    }
+
+    const buffer = this.bufferCache.get(state.clipId);
+
+    if (!buffer) {
+      return;
+    }
+
+    const source = this.context.createBufferSource();
+    source.buffer = buffer;
+    source.loop = state.loop;
+    source.playbackRate.value = state.pitch;
+    source.connect(state.gainNode);
+    source.start(0, state.pausedAt);
+
+    source.onended = () => {
+      if (!state.paused) {
+        this.cleanupSource(id);
+      }
+    };
+
+    state.source = source;
+    state.paused = false;
+    state.startedAt = this.context.currentTime - state.pausedAt;
+  }
+
+  /** Whether a source with the given id is currently active. */
+  isPlaying(id: string) {
+    const state = this.activeSources.get(id);
+    return state !== undefined && !state.paused;
+  }
+
+  /** Number of active sources. */
+  get activeSourceCount() {
+    return this.activeSources.size;
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Dispose
+  // ---------------------------------------------------------------------------
+
+  /** Dispose the AudioManager and release all resources. */
+  dispose() {
+    this.stopAll();
+    this.bufferCache.clear();
+    this.pendingLoads.clear();
+    for (const gain of Object.values(this.channelGains)) {
+      gain.disconnect();
+    }
+    this.masterGain.disconnect();
+    void this.context.close();
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Private
+  // ---------------------------------------------------------------------------
+
+  private stopById(id: string) {
+    const state = this.activeSources.get(id);
+
+    if (!state) {
+      return;
+    }
+
+    if (state.source) {
+      state.source.onended = null;
+
+      try {
+        state.source.stop();
+      } catch {
+        // Already stopped.
+      }
+
+      state.source.disconnect();
+    }
+
+    this.cleanupSource(id);
+  }
+
+  private cleanupSource(id: string) {
+    const state = this.activeSources.get(id);
+
+    if (!state) {
+      return;
+    }
+
+    state.gainNode.disconnect();
+    state.pannerNode?.disconnect();
+    this.activeSources.delete(id);
+  }
+
+  private createHandle(id: string): AudioSourceHandle {
+    return {
+      id,
+      pause: () => this.pause(id),
+      resume: () => void this.resumeSource(id),
+      setPosition: (position: Vec3) => {
+        const state = this.activeSources.get(id);
+
+        if (state?.pannerNode) {
+          state.pannerNode.positionX.value = position.x;
+          state.pannerNode.positionY.value = position.y;
+          state.pannerNode.positionZ.value = position.z;
+        }
+      },
+      setPitch: (rate: number) => {
+        const state = this.activeSources.get(id);
+
+        if (state) {
+          state.pitch = rate;
+
+          if (state.source) {
+            state.source.playbackRate.value = rate;
+          }
+        }
+      },
+      setVolume: (volume: number) => {
+        const state = this.activeSources.get(id);
+
+        if (state) {
+          state.gainNode.gain.value = Math.max(0, Math.min(1, volume));
+        }
+      },
+      stop: () => this.stopById(id)
+    };
+  }
+}
+
+/** Create a new AudioManager instance. */
+export function createAudioManager(options: AudioManagerOptions): AudioManager {
+  return new AudioManager(options);
+}

--- a/packages/runtime-audio/src/descriptors.ts
+++ b/packages/runtime-audio/src/descriptors.ts
@@ -1,0 +1,96 @@
+import type { Entity, GameplayObject, GameplayValue, GeometryNode } from "@ggez/shared";
+import type { RuntimeAudioEmitterDescriptor, AudioDistanceModel } from "./types";
+
+/**
+ * Extract audio emitter descriptors from entities and nodes that have `audio_emitter` hooks.
+ * This is the audio equivalent of `getRuntimePhysicsDescriptors`.
+ */
+export function getRuntimeAudioDescriptors(scene: {
+  entities?: Array<Pick<Entity, "hooks" | "id" | "transform">>;
+  nodes?: Array<Pick<GeometryNode, "hooks" | "id" | "transform">>;
+}): RuntimeAudioEmitterDescriptor[] {
+  const descriptors: RuntimeAudioEmitterDescriptor[] = [];
+
+  scene.entities?.forEach((entity) => {
+    entity.hooks?.forEach((hook) => {
+      if (hook.type !== "audio_emitter") {
+        return;
+      }
+
+      const descriptor = resolveAudioDescriptor(hook.id, entity.id, hook.config, entity.transform.position);
+      if (descriptor) {
+        descriptors.push(descriptor);
+      }
+    });
+  });
+
+  scene.nodes?.forEach((node) => {
+    node.hooks?.forEach((hook) => {
+      if (hook.type !== "audio_emitter") {
+        return;
+      }
+
+      const descriptor = resolveAudioDescriptor(hook.id, node.id, hook.config, node.transform.position);
+      if (descriptor) {
+        descriptors.push(descriptor);
+      }
+    });
+  });
+
+  return descriptors;
+}
+
+function resolveAudioDescriptor(
+  hookId: string,
+  targetId: string,
+  config: GameplayObject,
+  position?: { x: number; y: number; z: number }
+): RuntimeAudioEmitterDescriptor | undefined {
+  const clip = readString(config.clip, "");
+
+  if (!clip) {
+    return undefined;
+  }
+
+  return {
+    autoPlay: readBoolean(config.autoPlay, false),
+    clip,
+    distanceModel: readDistanceModel(config.distanceModel),
+    hookId,
+    loop: readBoolean(config.loop, false),
+    maxDistance: readNumber(config.maxDistance, 10000),
+    pitch: readNumber(config.pitch, 1),
+    position: position ? { x: position.x, y: position.y, z: position.z } : undefined,
+    refDistance: readNumber(config.refDistance, 1),
+    rolloffFactor: readNumber(config.rolloffFactor, 1),
+    spatial: readBoolean(config.spatial, false),
+    stopEvent: readOptionalString(config.stopEvent),
+    targetId,
+    triggerEvent: readOptionalString(config.triggerEvent),
+    volume: readNumber(config.volume, 1)
+  };
+}
+
+function readString(value: GameplayValue | undefined, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function readOptionalString(value: GameplayValue | undefined): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readNumber(value: GameplayValue | undefined, fallback: number): number {
+  return typeof value === "number" ? value : fallback;
+}
+
+function readBoolean(value: GameplayValue | undefined, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function readDistanceModel(value: GameplayValue | undefined): AudioDistanceModel {
+  if (value === "linear" || value === "exponential" || value === "inverse") {
+    return value;
+  }
+
+  return "inverse";
+}

--- a/packages/runtime-audio/src/index.ts
+++ b/packages/runtime-audio/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./audio-manager";
+export * from "./descriptors";
+export * from "./presets";

--- a/packages/runtime-audio/src/presets.ts
+++ b/packages/runtime-audio/src/presets.ts
@@ -1,0 +1,212 @@
+import type { AudioPlayOptions } from "./types";
+
+/**
+ * Preset partial options that can be spread into an `AudioPlayOptions`.
+ *
+ * Usage:
+ * ```ts
+ * audioManager.play({ clip: "door_open.ogg", ...AUDIO_EMITTER_PRESETS.mechanism });
+ * audioManager.play({ clip: "rain.ogg", ...AUDIO_EMITTER_PRESETS.ambientZone, position });
+ * ```
+ */
+export type AudioEmitterPreset = Omit<AudioPlayOptions, "clip" | "id" | "position">;
+
+// ---------------------------------------------------------------------------
+//  Emitter presets — define *how* a source behaves (spatial, loop, volume…)
+// ---------------------------------------------------------------------------
+
+/** Small, localized 3D sound. Footsteps, switches, impacts. */
+const pointSource: AudioEmitterPreset = {
+  distanceModel: "inverse",
+  loop: false,
+  maxDistance: 50,
+  pitch: 1,
+  refDistance: 1,
+  rolloffFactor: 1,
+  spatial: true,
+  volume: 1
+};
+
+/** Ambient background loop, non-spatial. Wind, city noise, music bed. */
+const ambientLoop: AudioEmitterPreset = {
+  loop: true,
+  spatial: false,
+  volume: 0.4
+};
+
+/** Spatial ambient zone — audible when inside an area. Water stream, fire crackle, machinery hum. */
+const ambientZone: AudioEmitterPreset = {
+  distanceModel: "linear",
+  loop: true,
+  maxDistance: 30,
+  refDistance: 5,
+  rolloffFactor: 1,
+  spatial: true,
+  volume: 0.6
+};
+
+/** Background music track, non-spatial, looped, lower volume. */
+const music: AudioEmitterPreset = {
+  loop: true,
+  spatial: false,
+  volume: 0.3
+};
+
+/** One-shot UI feedback sound — button clicks, notifications. */
+const ui: AudioEmitterPreset = {
+  loop: false,
+  spatial: false,
+  volume: 0.7
+};
+
+/** Voice / dialogue line, non-spatial, one-shot, full volume. */
+const dialogue: AudioEmitterPreset = {
+  loop: false,
+  spatial: false,
+  volume: 1
+};
+
+/** Spatial dialogue — NPC speaking in the world. */
+const dialogue3d: AudioEmitterPreset = {
+  distanceModel: "inverse",
+  loop: false,
+  maxDistance: 30,
+  refDistance: 2,
+  rolloffFactor: 1.5,
+  spatial: true,
+  volume: 1
+};
+
+/** Close-range mechanical sound — door hinge, valve turn, lever pull. */
+const mechanism: AudioEmitterPreset = {
+  distanceModel: "inverse",
+  loop: false,
+  maxDistance: 20,
+  pitch: 1,
+  refDistance: 0.5,
+  rolloffFactor: 2,
+  spatial: true,
+  volume: 0.8
+};
+
+/** Weapon or explosion — loud, travels far. */
+const weapon: AudioEmitterPreset = {
+  distanceModel: "inverse",
+  loop: false,
+  maxDistance: 200,
+  refDistance: 5,
+  rolloffFactor: 0.8,
+  spatial: true,
+  volume: 1
+};
+
+/** Footstep — very short range, quiet. */
+const footstep: AudioEmitterPreset = {
+  distanceModel: "inverse",
+  loop: false,
+  maxDistance: 15,
+  refDistance: 0.5,
+  rolloffFactor: 2,
+  spatial: true,
+  volume: 0.5
+};
+
+/** Large environmental element — waterfall, generator, train. Audible from far away. */
+const environmental: AudioEmitterPreset = {
+  distanceModel: "linear",
+  loop: true,
+  maxDistance: 100,
+  refDistance: 10,
+  rolloffFactor: 1,
+  spatial: true,
+  volume: 0.7
+};
+
+/** Collectible pickup jingle — non-spatial, slightly pitched up. */
+const pickup: AudioEmitterPreset = {
+  loop: false,
+  pitch: 1.1,
+  spatial: false,
+  volume: 0.8
+};
+
+export const AUDIO_EMITTER_PRESETS = {
+  ambientLoop,
+  ambientZone,
+  dialogue,
+  dialogue3d,
+  environmental,
+  footstep,
+  mechanism,
+  music,
+  pickup,
+  pointSource,
+  ui,
+  weapon
+} as const;
+
+// ---------------------------------------------------------------------------
+//  Attenuation presets — spatial distance curves for different environments
+// ---------------------------------------------------------------------------
+
+export type AudioAttenuationPreset = Pick<
+  AudioPlayOptions,
+  "distanceModel" | "maxDistance" | "refDistance" | "rolloffFactor"
+>;
+
+/** Tight indoor space — sound drops off quickly. */
+const indoor: AudioAttenuationPreset = {
+  distanceModel: "inverse",
+  maxDistance: 25,
+  refDistance: 1,
+  rolloffFactor: 2.5
+};
+
+/** Standard outdoor environment — gradual falloff. */
+const outdoor: AudioAttenuationPreset = {
+  distanceModel: "inverse",
+  maxDistance: 150,
+  refDistance: 5,
+  rolloffFactor: 0.6
+};
+
+/** Large reverberant space — cathedral, warehouse, canyon. */
+const cathedral: AudioAttenuationPreset = {
+  distanceModel: "inverse",
+  maxDistance: 200,
+  refDistance: 8,
+  rolloffFactor: 0.4
+};
+
+/** Very close range — whisper, tiny mechanism, breathing. */
+const intimate: AudioAttenuationPreset = {
+  distanceModel: "exponential",
+  maxDistance: 5,
+  refDistance: 0.3,
+  rolloffFactor: 3
+};
+
+/** Underwater or heavily dampened environment. */
+const underwater: AudioAttenuationPreset = {
+  distanceModel: "exponential",
+  maxDistance: 20,
+  refDistance: 1,
+  rolloffFactor: 4
+};
+
+/** Linear falloff — useful for clearly defined audio zones. */
+const linearZone: AudioAttenuationPreset = {
+  distanceModel: "linear",
+  maxDistance: 30,
+  refDistance: 5,
+  rolloffFactor: 1
+};
+
+export const AUDIO_ATTENUATION_PRESETS = {
+  cathedral,
+  indoor,
+  intimate,
+  linearZone,
+  outdoor,
+  underwater
+} as const;

--- a/packages/runtime-audio/src/types.ts
+++ b/packages/runtime-audio/src/types.ts
@@ -1,0 +1,78 @@
+import type { Vec3 } from "@ggez/shared";
+
+/** Resolves a clip identifier to raw audio data the AudioManager can decode. */
+export type AudioClipResolver = (clipId: string) => Promise<ArrayBuffer> | ArrayBuffer;
+
+/** Web Audio API distance model for spatial attenuation. */
+export type AudioDistanceModel = "exponential" | "inverse" | "linear";
+
+/** Describes a single audio source managed by the AudioManager. */
+export type AudioSourceState = {
+  channel: AudioChannel;
+  clipId: string;
+  gainNode: GainNode;
+  id: string;
+  loop: boolean;
+  pannerNode?: PannerNode;
+  pitch: number;
+  source?: AudioBufferSourceNode;
+  spatial: boolean;
+  startedAt: number;
+  pausedAt: number;
+  paused: boolean;
+};
+
+/** Audio mixer channel name. */
+export type AudioChannel = "ambient" | "music" | "sfx" | "ui" | "voice";
+
+/** Options for playing a clip through the AudioManager. */
+export type AudioPlayOptions = {
+  channel?: AudioChannel;
+  clip: string;
+  distanceModel?: AudioDistanceModel;
+  id?: string;
+  loop?: boolean;
+  maxDistance?: number;
+  pitch?: number;
+  position?: Vec3;
+  refDistance?: number;
+  rolloffFactor?: number;
+  spatial?: boolean;
+  volume?: number;
+};
+
+/** Handle returned after playing a clip, allows controlling playback. */
+export type AudioSourceHandle = {
+  readonly id: string;
+  pause: () => void;
+  resume: () => void;
+  setPosition: (position: Vec3) => void;
+  setPitch: (rate: number) => void;
+  setVolume: (volume: number) => void;
+  stop: () => void;
+};
+
+/** Configuration for creating an AudioManager. */
+export type AudioManagerOptions = {
+  clipResolver: AudioClipResolver;
+  masterVolume?: number;
+};
+
+/** Descriptor extracted from a runtime scene for an audio emitter. */
+export type RuntimeAudioEmitterDescriptor = {
+  autoPlay: boolean;
+  clip: string;
+  distanceModel: AudioDistanceModel;
+  hookId: string;
+  loop: boolean;
+  maxDistance: number;
+  pitch: number;
+  position?: Vec3;
+  refDistance: number;
+  rolloffFactor: number;
+  spatial: boolean;
+  stopEvent?: string;
+  targetId: string;
+  triggerEvent?: string;
+  volume: number;
+};

--- a/packages/runtime-audio/tsconfig.json
+++ b/packages/runtime-audio/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "include": ["src/**/*"]
+}

--- a/packages/runtime-format/src/audio.ts
+++ b/packages/runtime-format/src/audio.ts
@@ -1,0 +1,53 @@
+import type { RuntimeAudioDescriptor, RuntimeScene } from "./types";
+
+/** Extract audio descriptors from entities and nodes that have `audio_emitter` hooks. */
+export function getRuntimeAudioDescriptors(
+  scene: Pick<RuntimeScene, "entities" | "nodes">
+): RuntimeAudioDescriptor[] {
+  const descriptors: RuntimeAudioDescriptor[] = [];
+
+  const processTarget = (targetId: string, hooks: RuntimeScene["entities"][number]["hooks"], transform?: { position: { x: number; y: number; z: number } }) => {
+    hooks?.forEach((hook) => {
+      if (hook.type !== "audio_emitter") {
+        return;
+      }
+
+      const clip = typeof hook.config.clip === "string" ? hook.config.clip : "";
+
+      if (!clip) {
+        return;
+      }
+
+      const position = transform?.position;
+
+      descriptors.push({
+        autoPlay: hook.config.autoPlay === true,
+        channel: typeof hook.config.channel === "string" ? hook.config.channel : "sfx",
+        clip,
+        distanceModel: typeof hook.config.distanceModel === "string" ? hook.config.distanceModel : "inverse",
+        hookId: hook.id,
+        loop: hook.config.loop === true,
+        maxDistance: typeof hook.config.maxDistance === "number" ? hook.config.maxDistance : 10000,
+        pitch: typeof hook.config.pitch === "number" ? hook.config.pitch : 1,
+        position: position ? { x: position.x, y: position.y, z: position.z } : undefined,
+        refDistance: typeof hook.config.refDistance === "number" ? hook.config.refDistance : 1,
+        rolloffFactor: typeof hook.config.rolloffFactor === "number" ? hook.config.rolloffFactor : 1,
+        spatial: hook.config.spatial === true,
+        stopEvent: typeof hook.config.stopEvent === "string" && hook.config.stopEvent.length > 0 ? hook.config.stopEvent : undefined,
+        targetId,
+        triggerEvent: typeof hook.config.triggerEvent === "string" && hook.config.triggerEvent.length > 0 ? hook.config.triggerEvent : undefined,
+        volume: typeof hook.config.volume === "number" ? hook.config.volume : 1
+      });
+    });
+  };
+
+  scene.entities.forEach((entity) => {
+    processTarget(entity.id, entity.hooks, entity.transform);
+  });
+
+  scene.nodes.forEach((node) => {
+    processTarget(node.id, node.hooks, node.transform);
+  });
+
+  return descriptors;
+}

--- a/packages/runtime-format/src/index.ts
+++ b/packages/runtime-format/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
+export * from "./audio";
 export * from "./format";
 export * from "./physics";

--- a/packages/runtime-format/src/types.ts
+++ b/packages/runtime-format/src/types.ts
@@ -122,6 +122,25 @@ export type RuntimeWorldIndex = {
   version: number;
 };
 
+export type RuntimeAudioDescriptor = {
+  autoPlay: boolean;
+  channel: string;
+  clip: string;
+  distanceModel: string;
+  hookId: string;
+  loop: boolean;
+  maxDistance: number;
+  pitch: number;
+  position?: { x: number; y: number; z: number };
+  refDistance: number;
+  rolloffFactor: number;
+  spatial: boolean;
+  stopEvent?: string;
+  targetId: string;
+  triggerEvent?: string;
+  volume: number;
+};
+
 export type WebHammerExportMaterial = RuntimeMaterial;
 export type WebHammerExportPrimitive = RuntimePrimitive;
 export type WebHammerExportGeometry = RuntimeGeometry;

--- a/packages/three-runtime/src/loader.ts
+++ b/packages/three-runtime/src/loader.ts
@@ -37,9 +37,11 @@ import { HDRLoader } from "three/examples/jsm/loaders/HDRLoader.js";
 import { MTLLoader } from "three/examples/jsm/loaders/MTLLoader.js";
 import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js";
 import {
+  getRuntimeAudioDescriptors,
   isRuntimeBundle,
   isRuntimeScene,
   parseRuntimeScene,
+  type RuntimeAudioDescriptor,
   type RuntimeScene
 } from "@ggez/runtime-format";
 import {
@@ -95,6 +97,7 @@ export type WebHammerSceneLodOptions = {
 };
 
 export type ThreeRuntimeSceneInstance = {
+  audioDescriptors: RuntimeAudioDescriptor[];
   dispose: () => void;
   entities: WebHammerEngineScene["entities"];
   lights: Object3D[];
@@ -254,6 +257,7 @@ export async function createThreeRuntimeSceneInstance(
   }
 
   return {
+    audioDescriptors: getRuntimeAudioDescriptors(engineScene),
     dispose() {
       disposeThreeRuntimeSceneInstance(root);
     },


### PR DESCRIPTION
## Summary

Adds a complete audio pipeline from editor configuration to Web Audio API playback, including a 5-channel mixer, spatial 3D audio, 12 procedural sound presets, and full test coverage.

## Architecture

```
Editor Hook (audio_emitter)
  → Gameplay AudioSystem (events: audio.play / audio.stop)
    → Playground bridge (event listener)
      → AudioManager (Web Audio API)
        → source → gainNode → [pannerNode] → channelGain → masterGain → destination
```

## New package: `@ggez/runtime-audio`

### AudioManager
- Web Audio API wrapper: clip loading with cache + concurrent dedup, decode, playback
- Spatial 3D audio via HRTF PannerNodes (inverse, linear, exponential distance models)
- Play / pause / resume / stop with pitch and volume control per source
- `AudioSourceHandle` returned from `play()` for live control

### Mixer (5 channels)
Independent volume control per channel, all routed through master gain:

| Channel | Use case |
|---------|----------|
| `sfx` | Footsteps, impacts, doors (default) |
| `music` | Background music tracks |
| `ambient` | Wind, rain, machinery loops |
| `ui` | Button clicks, notifications |
| `voice` | Dialogue, NPC speech |

```ts
audioManager.setChannelVolume("music", 0.3);
audioManager.setChannelVolume("ambient", 0.5);
audioManager.stopChannel("music");
```

### Presets
12 emitter presets (`AUDIO_EMITTER_PRESETS`): pointSource, ambientLoop, ambientZone, music, ui, dialogue, dialogue3d, mechanism, weapon, footstep, environmental, pickup

6 attenuation presets (`AUDIO_ATTENUATION_PRESETS`): indoor, outdoor, cathedral, intimate, underwater, linearZone

### Descriptor extraction
`getRuntimeAudioDescriptors()` extracts audio emitter configurations from scene entities/nodes.

---

## Gameplay AudioSystem (`gameplay-runtime`)

The `createAudioSystemDefinition()` system reads `audio_emitter` hooks and:
- Emits `audio.play` on `autoPlay` at start, or when `triggerEvent` fires
- Emits `audio.stop` when `stopEvent` fires
- Handles `audio.stop_all` global event
- Payload includes: clip, channel, volume, pitch, loop, spatial, distanceModel, refDistance, maxDistance, rolloffFactor, world position

---

## Playground integration

Both vanilla and React playgrounds:
- Create `AudioManager` with `clipResolver` using `resolveAssetPath → fetch → ArrayBuffer`
- Forward `audio.play` / `audio.stop` events to `AudioManager.play()` / `.stop()`
- `AudioContext.resume()` on first user gesture
- Audio system toggle in the UI panel
- `.whmap` file import support (auto-converts editor format)
- 12 procedural audio generators for sample clips (wind, rain, water, machinery, chime, footstep, click, alarm, explosion, pickup, door-slide, ambient-hum)

---

## Editor

`audio_emitter` hook definition updated with 14 config fields:
- Clip, Channel (sfx/music/ambient/ui/voice), Volume, Pitch, Loop, Auto Play
- Spatial toggle with conditional fields: Distance Model, Ref Distance, Max Distance, Rolloff Factor
- Trigger Event, Stop Event

---

## Bug fixes

| Bug | Fix |
|-----|-----|
| Pitch lost on pause/resume | `pitch` persisted in `AudioSourceState`, restored on `resumeSource()` |
| `setPitch()` didn't update state | Now updates `state.pitch` alongside live source |
| Empty clip silent failure | `emitAudioPlay()` early-returns on empty clip |
| Double clip read | `emitAudioPlay()` uses local variable instead of reading config twice |
| No error context on load failure | `loadClip()` wraps errors with `AudioManager: failed to load clip "..."` |
| Concurrent load race | `pendingLoads` Map deduplicates in-flight fetches for same clip |

---

## Tests (42 cases, 5 files)

| File | Cases | Coverage |
|------|-------|----------|
| `runtime-format/audio.test.ts` | 7 | Extraction, defaults, all fields, skip empty/non-audio, multi-target |
| `runtime-audio/descriptors.test.ts` | 6 | Entity/node extraction, fallbacks, optional strings, position |
| `runtime-audio/presets.test.ts` | 7 | Volume range, distance model validity, spatial constraints, pitch, keys |
| `runtime-audio/audio-manager.test.ts` | 12 | Play/cache/stop/pause/resume, pitch regression, spatial, stopAll, error wrap, oneShot, masterVolume, dispose |
| `gameplay-runtime/audio-system.test.ts` | 10 | autoPlay, enabled=false, triggerEvent, stopEvent, stop_all, payload, position, empty clip, listener cleanup |

---

## Test map

`test-audio-map.whmap` — 12 audio zones demonstrating all sound types:

| Sound | Type | Trigger |
|-------|------|---------|
| Wind | Non-spatial ambient | autoPlay loop |
| Water Stream | Spatial inverse | autoPlay loop |
| Machinery Hum | Spatial inverse | autoPlay loop |
| Rain | Spatial linear | autoPlay loop |
| Bell Chime | Spatial inverse, pitch 0.7 | autoPlay loop |
| Energy Hum | Spatial exponential, pitch 1.3 | autoPlay loop |
| Door Slide | Spatial, 2 pitches | open.started / close.started |
| Alarm Siren | Spatial sweep | trigger.enter (once) |
| Coin Pickup | Non-spatial arpeggio | trigger.enter (once) |
| Explosion | Spatial noise+rumble | trigger.enter (once) |
| Footstep | Spatial impact | trigger.enter (cooldown 0.4s) |
| UI Click | Spatial click | trigger.enter (cooldown 1s) |

## Test plan

- [x] `bun test packages/runtime-audio/` — 25 pass
- [x] `bun test packages/runtime-format/src/audio.test.ts` — 7 pass
- [x] `bun test packages/gameplay-runtime/src/audio-system.test.ts` — 10 pass
- [x] Import `test-audio-map.whmap` in vanilla playground → Play → walk around, hear spatial sounds
- [x] Verify autoPlay sounds start on first click
- [x] Verify trigger sounds fire on proximity
- [x] Verify door opens/closes with different pitched slide sounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)