### PR TITLE
Unreal logic UI (node/hook)

### DIFF
--- a/apps/editor/src/components/editor-shell/InspectorSidebar.tsx
+++ b/apps/editor/src/components/editor-shell/InspectorSidebar.tsx
@@ -806,6 +806,38 @@ export function InspectorSidebar({
                     value={draftPlayerSettings.crouchHeight}
                   />
                 </ToolSection>
+
+                <ToolSection title="Interaction">
+                  <BooleanField
+                    label="Allow Interact"
+                    onCheckedChange={(checked) => {
+                      const nextPlayer = { ...draftPlayerSettings, canInteract: checked };
+                      setDraftPlayerSettings(nextPlayer);
+                      onUpdateSceneSettings(
+                        {
+                          ...sceneSettings,
+                          player: nextPlayer
+                        },
+                        sceneSettings
+                      );
+                    }}
+                    checked={draftPlayerSettings.canInteract ?? true}
+                  />
+                  <InteractKeyField
+                    value={draftPlayerSettings.interactKey ?? "KeyE"}
+                    onChange={(code) => {
+                      const nextPlayer = { ...draftPlayerSettings, interactKey: code };
+                      setDraftPlayerSettings(nextPlayer);
+                      onUpdateSceneSettings(
+                        {
+                          ...sceneSettings,
+                          player: nextPlayer
+                        },
+                        sceneSettings
+                      );
+                    }}
+                  />
+                </ToolSection>
               </div>
             </ScrollArea>
           </TabsContent>
@@ -1475,6 +1507,51 @@ function ColorField({
         type="color"
         value={value}
       />
+    </div>
+  );
+}
+
+function InteractKeyField({
+  value,
+  onChange
+}: {
+  value: string;
+  onChange: (code: string) => void;
+}) {
+  const [listening, setListening] = useState(false);
+
+  useEffect(() => {
+    if (!listening) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onChange(event.code);
+      setListening(false);
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [listening, onChange]);
+
+  const displayLabel = value.replace(/^Key/, "").replace(/^Digit/, "");
+
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-xl bg-white/3 px-3 py-2">
+      <span className="text-xs text-foreground/72">Interact Key</span>
+      <Button
+        className={cn(listening && "bg-emerald-500/18 text-emerald-200")}
+        onClick={() => setListening((current) => !current)}
+        size="xs"
+        variant="ghost"
+      >
+        {listening ? "Press a key..." : displayLabel}
+      </Button>
     </div>
   );
 }

--- a/apps/editor/src/components/editor-shell/logic-viewer/LogicClusterNode.tsx
+++ b/apps/editor/src/components/editor-shell/logic-viewer/LogicClusterNode.tsx
@@ -1,0 +1,36 @@
+import { type NodeProps } from "@xyflow/react";
+import { memo } from "react";
+import { getCategoryColor } from "./logic-theme";
+
+export type LogicClusterData = {
+  label: string;
+  category: string;
+  width: number;
+  height: number;
+};
+
+function LogicClusterNodeComponent({ data }: NodeProps & { data: LogicClusterData }) {
+  const color = getCategoryColor(data.category);
+
+  return (
+    <div
+      className="rounded-3xl"
+      style={{
+        width: data.width,
+        height: data.height,
+        background: `linear-gradient(160deg, ${color.edge}08 0%, ${color.edge}03 100%)`,
+        border: `1px dashed ${color.edge}18`,
+        pointerEvents: "none"
+      }}
+    >
+      <div
+        className="px-4 py-2.5 text-[10px] font-bold tracking-widest uppercase"
+        style={{ color: `${color.text}50` }}
+      >
+        {data.label}
+      </div>
+    </div>
+  );
+}
+
+export const LogicClusterNode = memo(LogicClusterNodeComponent);

--- a/apps/editor/src/components/editor-shell/logic-viewer/LogicEdge.tsx
+++ b/apps/editor/src/components/editor-shell/logic-viewer/LogicEdge.tsx
@@ -1,0 +1,82 @@
+import { type EdgeProps, getSmoothStepPath, EdgeLabelRenderer } from "@xyflow/react";
+import { memo } from "react";
+import { getEdgeColor } from "./logic-theme";
+
+type LogicEdgeData = {
+  event: string;
+  category: string;
+};
+
+function LogicEdgeComponent({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+  markerEnd
+}: EdgeProps & { data?: LogicEdgeData }) {
+  const category = data?.category ?? "Custom";
+  const event = data?.event ?? "";
+  const color = getEdgeColor(category);
+
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    borderRadius: 16,
+    offset: 24
+  });
+
+  return (
+    <>
+      {/* Glow layer */}
+      <path
+        d={edgePath}
+        fill="none"
+        stroke={color}
+        strokeWidth={6}
+        strokeOpacity={0.12}
+        className="react-flow__edge-path"
+      />
+      {/* Main stroke */}
+      <path
+        id={id}
+        d={edgePath}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.5}
+        strokeOpacity={0.55}
+        className="react-flow__edge-path"
+        markerEnd={markerEnd}
+      />
+      {/* Event label */}
+      <EdgeLabelRenderer>
+        <div
+          className="nodrag nopan pointer-events-none absolute"
+          style={{
+            transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            fontSize: 8,
+            fontFamily: "monospace",
+            color,
+            opacity: 0.5,
+            background: "rgba(6,13,11,0.85)",
+            padding: "1px 5px",
+            borderRadius: 4,
+            border: `1px solid ${color}25`,
+            whiteSpace: "nowrap"
+          }}
+        >
+          {event}
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+}
+
+export const LogicEdge = memo(LogicEdgeComponent);

--- a/apps/editor/src/components/editor-shell/logic-viewer/LogicNode.tsx
+++ b/apps/editor/src/components/editor-shell/logic-viewer/LogicNode.tsx
@@ -1,0 +1,225 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { memo, useMemo } from "react";
+import type { LogicGraphHook } from "./types";
+import { getCategoryColor } from "./logic-theme";
+
+export type LogicNodeData = {
+  label: string;
+  kind: string;
+  hooks: LogicGraphHook[];
+};
+
+const HEADER_HEIGHT = 38;
+const HOOK_HEADER_HEIGHT = 26;
+const PORT_ROW_HEIGHT = 24;
+const NODE_BOTTOM_PAD = 8;
+
+type PortRow = {
+  inputId?: string;
+  inputEvent?: string;
+  outputId?: string;
+  outputEvent?: string;
+  category: string;
+};
+
+type HookSection = {
+  hook: LogicGraphHook;
+  portRows: PortRow[];
+};
+
+function buildSections(hooks: LogicGraphHook[]): HookSection[] {
+  return hooks.map((hook) => {
+    const inputs: Array<{ id: string; event: string }> = [];
+    const outputs: Array<{ id: string; event: string }> = [];
+
+    const seenIn = new Set<string>();
+    const seenOut = new Set<string>();
+
+    for (const event of hook.listens) {
+      const id = `${hook.hookId}:listen:${event}`;
+      if (!seenIn.has(id)) { seenIn.add(id); inputs.push({ id, event }); }
+    }
+    for (const dl of hook.dynamicListens) {
+      const id = `${hook.hookId}:listen:${dl.event}`;
+      if (!seenIn.has(id)) { seenIn.add(id); inputs.push({ id, event: dl.event }); }
+    }
+
+    for (const event of hook.emits) {
+      const id = `${hook.hookId}:emit:${event}`;
+      if (!seenOut.has(id)) { seenOut.add(id); outputs.push({ id, event }); }
+    }
+    for (const de of hook.dynamicEmits) {
+      const id = `${hook.hookId}:emit:${de.event}`;
+      if (!seenOut.has(id)) { seenOut.add(id); outputs.push({ id, event: de.event }); }
+    }
+
+    const rowCount = Math.max(inputs.length, outputs.length, 1);
+    const portRows: PortRow[] = [];
+
+    for (let i = 0; i < rowCount; i++) {
+      portRows.push({
+        inputId: inputs[i]?.id,
+        inputEvent: inputs[i]?.event,
+        outputId: outputs[i]?.id,
+        outputEvent: outputs[i]?.event,
+        category: hook.category
+      });
+    }
+
+    return { hook, portRows };
+  });
+}
+
+export function computeNodeHeight(hooks: LogicGraphHook[]): number {
+  const sections = buildSections(hooks);
+  let h = HEADER_HEIGHT;
+  for (const section of sections) {
+    h += HOOK_HEADER_HEIGHT + section.portRows.length * PORT_ROW_HEIGHT;
+  }
+  return h + NODE_BOTTOM_PAD;
+}
+
+function LogicNodeComponent({ data, selected }: NodeProps & { data: LogicNodeData }) {
+  const { label, kind, hooks } = data;
+
+  const sections = useMemo(() => buildSections(hooks), [hooks]);
+
+  const allHandles: Array<{
+    id: string;
+    type: "source" | "target";
+    y: number;
+    category: string;
+  }> = [];
+
+  let y = HEADER_HEIGHT;
+  for (const section of sections) {
+    y += HOOK_HEADER_HEIGHT;
+    for (const row of section.portRows) {
+      const rowCenter = y + PORT_ROW_HEIGHT / 2;
+      if (row.inputId) {
+        allHandles.push({ id: row.inputId, type: "target", y: rowCenter, category: row.category });
+      }
+      if (row.outputId) {
+        allHandles.push({ id: row.outputId, type: "source", y: rowCenter, category: row.category });
+      }
+      y += PORT_ROW_HEIGHT;
+    }
+  }
+
+  const nodeHeight = computeNodeHeight(hooks);
+
+  return (
+    <div
+      className="rounded-2xl border bg-[#0a1410]/80 shadow-[0_12px_48px_rgba(0,0,0,0.55)] backdrop-blur-xl transition-[border-color,box-shadow] duration-150 cursor-pointer"
+      style={{
+        width: 300,
+        minHeight: nodeHeight,
+        borderColor: selected ? "rgba(16,185,129,0.5)" : "rgba(255,255,255,0.06)",
+        boxShadow: selected
+          ? "0 0 0 1px rgba(16,185,129,0.25), 0 12px 48px rgba(0,0,0,0.55), 0 0 24px rgba(16,185,129,0.08)"
+          : "0 12px 48px rgba(0,0,0,0.55)"
+      }}
+    >
+      {/* Header */}
+      <div
+        className="flex items-center justify-between gap-2 rounded-t-2xl px-3.5"
+        style={{
+          height: HEADER_HEIGHT,
+          background: "linear-gradient(135deg, rgba(16,185,129,0.10) 0%, rgba(16,185,129,0.03) 100%)",
+          borderBottom: "1px solid rgba(255,255,255,0.05)"
+        }}
+      >
+        <span className="truncate text-[11px] font-semibold tracking-wide text-foreground/90">{label}</span>
+        <span className="shrink-0 rounded-[5px] bg-white/[0.07] px-1.5 py-[2px] text-[8px] font-bold tracking-widest text-foreground/40 uppercase">
+          {kind}
+        </span>
+      </div>
+
+      {/* Hook sections */}
+      {sections.map((section) => {
+        const color = getCategoryColor(section.hook.category);
+        return (
+          <div key={section.hook.hookId} style={{ opacity: section.hook.enabled ? 1 : 0.35 }}>
+            {/* Hook section header */}
+            <div
+              className="flex items-center gap-2 px-3.5"
+              style={{
+                height: HOOK_HEADER_HEIGHT,
+                borderBottom: "1px solid rgba(255,255,255,0.03)"
+              }}
+            >
+              <div className="size-[6px] shrink-0 rounded-full" style={{ backgroundColor: color.text, boxShadow: `0 0 6px ${color.edge}` }} />
+              <span className="text-[10px] font-semibold text-foreground/60">{section.hook.label}</span>
+              <span className="ml-auto text-[8px] font-bold tracking-wider uppercase" style={{ color: color.text, opacity: 0.6 }}>
+                {section.hook.category}
+              </span>
+            </div>
+
+            {/* Port rows */}
+            {section.portRows.map((row, rowIndex) => (
+              <div
+                key={row.inputId ?? row.outputId ?? `${section.hook.hookId}-${rowIndex}`}
+                className="flex items-center justify-between px-3.5"
+                style={{ height: PORT_ROW_HEIGHT }}
+              >
+                {/* Input (left) */}
+                <div className="flex items-center gap-1.5 min-w-0">
+                  {row.inputEvent ? (
+                    <>
+                      <div
+                        className="size-[5px] shrink-0 rounded-full"
+                        style={{
+                          backgroundColor: getCategoryColor(row.category).edge,
+                          boxShadow: `0 0 4px ${getCategoryColor(row.category).edge}40, 0 0 0 1px ${getCategoryColor(row.category).border}`
+                        }}
+                      />
+                      <span className="truncate text-[9px] font-mono text-foreground/45">{row.inputEvent}</span>
+                    </>
+                  ) : <span />}
+                </div>
+
+                {/* Output (right) */}
+                <div className="flex items-center gap-1.5 min-w-0 justify-end">
+                  {row.outputEvent ? (
+                    <>
+                      <span className="truncate text-[9px] font-mono text-foreground/45">{row.outputEvent}</span>
+                      <div
+                        className="size-[5px] shrink-0 rounded-full"
+                        style={{
+                          backgroundColor: getCategoryColor(row.category).edge,
+                          boxShadow: `0 0 4px ${getCategoryColor(row.category).edge}40, 0 0 0 1px ${getCategoryColor(row.category).border}`
+                        }}
+                      />
+                    </>
+                  ) : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        );
+      })}
+
+      {/* Handles — positioned absolutely */}
+      {allHandles.map((handle) => (
+        <Handle
+          key={handle.id}
+          id={handle.id}
+          type={handle.type}
+          position={handle.type === "target" ? Position.Left : Position.Right}
+          style={{
+            top: handle.y,
+            width: 10,
+            height: 10,
+            background: getCategoryColor(handle.category).edge,
+            border: "2px solid rgba(0,0,0,0.5)",
+            boxShadow: `0 0 6px ${getCategoryColor(handle.category).edge}60`,
+            borderRadius: "50%"
+          }}
+          isConnectable
+        />
+      ))}
+    </div>
+  );
+}
+
+export const LogicNode = memo(LogicNodeComponent);

--- a/apps/editor/src/components/editor-shell/logic-viewer/LogicViewer.tsx
+++ b/apps/editor/src/components/editor-shell/logic-viewer/LogicViewer.tsx
@@ -1,0 +1,212 @@
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  type Node,
+  type Edge,
+  type NodeChange,
+  type Connection,
+  applyNodeChanges,
+  useReactFlow
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Entity, GeometryNode, SceneHook } from "@ggez/shared";
+import { deriveLogicGraph } from "./logic-graph";
+import { layoutGraph, NODE_WIDTH } from "./logic-layout";
+import { LogicNode, computeNodeHeight, type LogicNodeData } from "./LogicNode";
+import { LogicEdge } from "./LogicEdge";
+import { LogicClusterNode } from "./LogicClusterNode";
+import { parseHandle, resolveConnection } from "./logic-connect";
+
+const nodeTypes = {
+  logic: LogicNode,
+  cluster: LogicClusterNode
+};
+const edgeTypes = { logic: LogicEdge };
+
+const CLUSTER_PAD = 40;
+
+type LogicViewerProps = {
+  nodes: GeometryNode[];
+  entities: Entity[];
+  onNodeClick?: (nodeId: string) => void;
+  onUpdateNodeHooks?: (nodeId: string, hooks: SceneHook[], beforeHooks: SceneHook[]) => void;
+  onUpdateEntityHooks?: (entityId: string, hooks: SceneHook[], beforeHooks: SceneHook[]) => void;
+};
+
+export function LogicViewer({
+  nodes,
+  entities,
+  onNodeClick,
+  onUpdateNodeHooks,
+  onUpdateEntityHooks
+}: LogicViewerProps) {
+  const [rfNodes, setRfNodes] = useState<Node[]>([]);
+
+  const { graph, positions } = useMemo(() => {
+    const g = deriveLogicGraph(nodes, entities);
+    const p = layoutGraph(g);
+    return { graph: g, positions: p };
+  }, [nodes, entities]);
+
+  // Build initial node list with clusters + logic nodes
+  useEffect(() => {
+    const clusterNodes: Node[] = [];
+    for (const cluster of graph.clusters) {
+      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+
+      for (const nid of cluster.nodeIds) {
+        const pos = positions.get(nid);
+        if (!pos) continue;
+        const gn = graph.nodes.find((n) => n.id === nid);
+        if (!gn) continue;
+        const h = computeNodeHeight(gn.hooks);
+        minX = Math.min(minX, pos.x);
+        minY = Math.min(minY, pos.y);
+        maxX = Math.max(maxX, pos.x + NODE_WIDTH);
+        maxY = Math.max(maxY, pos.y + h);
+      }
+
+      if (!isFinite(minX)) continue;
+
+      const width = maxX - minX + CLUSTER_PAD * 2;
+      const height = maxY - minY + CLUSTER_PAD * 2;
+
+      clusterNodes.push({
+        id: cluster.id,
+        type: "cluster",
+        position: { x: minX - CLUSTER_PAD, y: minY - CLUSTER_PAD },
+        data: { label: cluster.label, category: cluster.dominantCategory, width, height },
+        zIndex: -1,
+        style: { width, height },
+        selectable: false,
+        draggable: false,
+        focusable: false
+      });
+    }
+
+    const logicNodes: Node[] = graph.nodes.map((node) => {
+      const pos = positions.get(node.id) ?? { x: 0, y: 0 };
+      const h = computeNodeHeight(node.hooks);
+      return {
+        id: node.id,
+        type: "logic",
+        position: pos,
+        data: { label: node.label, kind: node.kind, hooks: node.hooks } satisfies LogicNodeData,
+        style: { width: NODE_WIDTH, height: h }
+      };
+    });
+
+    setRfNodes([...clusterNodes, ...logicNodes]);
+  }, [graph, positions]);
+
+  const rfEdges: Edge[] = useMemo(
+    () =>
+      graph.edges.map((edge) => ({
+        id: edge.id,
+        source: edge.sourceNodeId,
+        sourceHandle: `${edge.sourceHookId}:emit:${edge.event}`,
+        target: edge.targetNodeId,
+        targetHandle: `${edge.targetHookId}:listen:${edge.event}`,
+        type: "logic",
+        data: { event: edge.event, category: edge.category },
+        animated: false
+      })),
+    [graph]
+  );
+
+  const handleNodesChange = useCallback((changes: NodeChange[]) => {
+    setRfNodes((nds) => applyNodeChanges(changes, nds));
+  }, []);
+
+  const handleNodeClick = useCallback(
+    (_event: React.MouseEvent, node: Node) => {
+      if (node.type === "cluster") return;
+      onNodeClick?.(node.id);
+    },
+    [onNodeClick]
+  );
+
+  const handleConnect = useCallback(
+    (connection: Connection) => {
+      if (!connection.source || !connection.target || !connection.sourceHandle || !connection.targetHandle) return;
+
+      const mutation = resolveConnection(
+        connection.source,
+        connection.sourceHandle,
+        connection.target,
+        connection.targetHandle,
+        nodes,
+        entities
+      );
+
+      if (!mutation) return;
+
+      if (mutation.ownerKind === "node") {
+        onUpdateNodeHooks?.(mutation.ownerId, mutation.hooks, mutation.beforeHooks);
+      } else {
+        onUpdateEntityHooks?.(mutation.ownerId, mutation.hooks, mutation.beforeHooks);
+      }
+    },
+    [nodes, entities, onUpdateNodeHooks, onUpdateEntityHooks]
+  );
+
+  return (
+    <div className="size-full">
+      <ReactFlow
+        nodes={rfNodes}
+        edges={rfEdges}
+        onNodesChange={handleNodesChange}
+        onNodeClick={handleNodeClick}
+        onConnect={handleConnect}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        fitView
+        fitViewOptions={{ padding: 0.15 }}
+        nodesDraggable
+        nodesConnectable
+        proOptions={{ hideAttribution: true }}
+        minZoom={0.05}
+        maxZoom={2.5}
+        snapToGrid
+        snapGrid={[16, 16]}
+        isValidConnection={(connection) => {
+          if (!connection.sourceHandle || !connection.targetHandle) return false;
+          if (connection.source === connection.target) return false;
+          const src = parseHandle(connection.sourceHandle);
+          const tgt = parseHandle(connection.targetHandle);
+          if (!src || !tgt) return false;
+          return src.direction === "emit" && tgt.direction === "listen";
+        }}
+        connectionLineStyle={{ stroke: "rgba(16,185,129,0.5)", strokeWidth: 2 }}
+      >
+        <Background color="rgba(255,255,255,0.025)" gap={32} size={1} />
+        <MiniMap
+          nodeColor={(node) =>
+            node.type === "cluster" ? "transparent" : "rgba(16,185,129,0.25)"
+          }
+          maskColor="rgba(0,0,0,0.65)"
+          style={{ background: "rgba(6,13,11,0.7)", borderRadius: 12, border: "1px solid rgba(255,255,255,0.06)" }}
+        />
+        <Controls
+          showInteractive={false}
+          style={{
+            background: "rgba(6,13,11,0.7)",
+            borderRadius: 12,
+            border: "1px solid rgba(255,255,255,0.06)",
+            boxShadow: "0 8px 32px rgba(0,0,0,0.4)"
+          }}
+        />
+      </ReactFlow>
+    </div>
+  );
+}
+
+export function useLogicViewerRelayout() {
+  const { fitView } = useReactFlow();
+  return useCallback(() => {
+    fitView({ duration: 300 });
+  }, [fitView]);
+}

--- a/apps/editor/src/components/editor-shell/logic-viewer/LogicViewerPanel.tsx
+++ b/apps/editor/src/components/editor-shell/logic-viewer/LogicViewerPanel.tsx
@@ -1,0 +1,59 @@
+import { Cable, X } from "lucide-react";
+import { ReactFlowProvider } from "@xyflow/react";
+import type { Entity, GeometryNode, SceneHook } from "@ggez/shared";
+import { LogicViewer } from "./LogicViewer";
+
+type LogicViewerPanelProps = {
+  nodes: GeometryNode[];
+  entities: Entity[];
+  onClose: () => void;
+  onNodeClick?: (nodeId: string) => void;
+  onUpdateNodeHooks?: (nodeId: string, hooks: SceneHook[], beforeHooks: SceneHook[]) => void;
+  onUpdateEntityHooks?: (entityId: string, hooks: SceneHook[], beforeHooks: SceneHook[]) => void;
+};
+
+export function LogicViewerPanel({
+  nodes,
+  entities,
+  onClose,
+  onNodeClick,
+  onUpdateNodeHooks,
+  onUpdateEntityHooks
+}: LogicViewerPanelProps) {
+  return (
+    <div className="flex size-full flex-col bg-[#060d0b]">
+      {/* Header bar */}
+      <div className="flex h-8 shrink-0 items-center justify-between border-b border-white/6 px-3">
+        <div className="flex items-center gap-2">
+          <Cable className="size-3.5 text-emerald-400" />
+          <span className="text-[11px] font-medium tracking-wide text-foreground/80 uppercase">
+            Logic
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            className="rounded-md p-1 text-foreground/50 transition hover:bg-white/6 hover:text-foreground/80"
+            onClick={onClose}
+            title="Close logic viewer"
+            type="button"
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Graph canvas */}
+      <div className="min-h-0 flex-1">
+        <ReactFlowProvider>
+          <LogicViewer
+            nodes={nodes}
+            entities={entities}
+            onNodeClick={onNodeClick}
+            onUpdateNodeHooks={onUpdateNodeHooks}
+            onUpdateEntityHooks={onUpdateEntityHooks}
+          />
+        </ReactFlowProvider>
+      </div>
+    </div>
+  );
+}

--- a/apps/editor/src/components/editor-shell/logic-viewer/logic-connect.ts
+++ b/apps/editor/src/components/editor-shell/logic-viewer/logic-connect.ts
@@ -1,0 +1,223 @@
+import type { Entity, GeometryNode, SceneHook } from "@ggez/shared";
+import { createGameplayId, isGameplayObject, toObjectArray } from "@/lib/gameplay";
+
+/**
+ * Parses a React Flow handle ID into its parts.
+ * Handle format: "{hookId}:emit:{event}" or "{hookId}:listen:{event}"
+ */
+export function parseHandle(handleId: string): { hookId: string; direction: "emit" | "listen"; event: string } | null {
+  const emitMatch = handleId.match(/^(.+?):emit:(.+)$/);
+  if (emitMatch) return { hookId: emitMatch[1], direction: "emit", event: emitMatch[2] };
+
+  const listenMatch = handleId.match(/^(.+?):listen:(.+)$/);
+  if (listenMatch) return { hookId: listenMatch[1], direction: "listen", event: listenMatch[2] };
+
+  return null;
+}
+
+type Owner = {
+  id: string;
+  kind: "node" | "entity";
+  hooks: SceneHook[];
+};
+
+function findOwner(ownerId: string, nodes: GeometryNode[], entities: Entity[]): Owner | null {
+  for (const node of nodes) {
+    if (node.id === ownerId && node.hooks) {
+      return { id: node.id, kind: "node", hooks: node.hooks };
+    }
+  }
+  for (const entity of entities) {
+    if (entity.id === ownerId && entity.hooks) {
+      return { id: entity.id, kind: "entity", hooks: entity.hooks };
+    }
+  }
+  return null;
+}
+
+export type ConnectionMutation = {
+  ownerId: string;
+  ownerKind: "node" | "entity";
+  hooks: SceneHook[];
+  beforeHooks: SceneHook[];
+};
+
+/**
+ * Given a new connection between two ports, determines the hook mutations needed.
+ *
+ * Strategy:
+ *  1. If the target hook has a dynamic listen that can accept a fromEntity → set it.
+ *  2. If the source hook has a dynamic emit that can accept a target → set it.
+ *  3. Otherwise, create a new "sequence" hook on the source owner:
+ *     trigger listens for sourceEvent from sourceNodeId,
+ *     action emits targetEvent to targetNodeId.
+ */
+export function resolveConnection(
+  sourceNodeId: string,
+  sourceHandleId: string,
+  targetNodeId: string,
+  targetHandleId: string,
+  nodes: GeometryNode[],
+  entities: Entity[]
+): ConnectionMutation | null {
+  const src = parseHandle(sourceHandleId);
+  const tgt = parseHandle(targetHandleId);
+  if (!src || !tgt) return null;
+
+  const sourceOwner = findOwner(sourceNodeId, nodes, entities);
+  const targetOwner = findOwner(targetNodeId, nodes, entities);
+  if (!sourceOwner || !targetOwner) return null;
+
+  const sourceHook = sourceOwner.hooks.find((h) => h.id === src.hookId);
+  const targetHook = targetOwner.hooks.find((h) => h.id === tgt.hookId);
+  if (!sourceHook || !targetHook) return null;
+
+  // --- Case 1: target hook has a dynamic listen we can bind ---
+  const targetMutation = tryBindListen(targetOwner, targetHook, tgt.event, sourceNodeId);
+  if (targetMutation) return targetMutation;
+
+  // --- Case 2: source hook has a dynamic emit we can bind ---
+  const sourceMutation = tryBindEmit(sourceOwner, sourceHook, src.event, targetNodeId);
+  if (sourceMutation) return sourceMutation;
+
+  // --- Case 3: create a new sequence on the source owner ---
+  return createBridgeSequence(sourceOwner, sourceNodeId, src.event, targetNodeId, tgt.event);
+}
+
+/**
+ * Try to set `fromEntity` on a dynamic listen port of the target hook.
+ */
+function tryBindListen(owner: Owner, hook: SceneHook, event: string, sourceNodeId: string): ConnectionMutation | null {
+  const config = structuredClone(hook.config);
+  let changed = false;
+
+  // sequence: config.trigger.event matches → set fromEntity
+  if (hook.type === "sequence" && isGameplayObject(config.trigger)) {
+    if (config.trigger.event === event) {
+      config.trigger.fromEntity = sourceNodeId;
+      changed = true;
+    }
+  }
+
+  // condition_listener: find matching entry in allOf/anyOf → set fromEntity
+  if (hook.type === "condition_listener") {
+    for (const arr of [toObjectArray(config.allOf), toObjectArray(config.anyOf)]) {
+      for (const cond of arr) {
+        if (cond.event === event && !cond.fromEntity) {
+          cond.fromEntity = sourceNodeId;
+          changed = true;
+          break;
+        }
+      }
+      if (changed) break;
+    }
+
+    // If no existing entry, add one to allOf
+    if (!changed) {
+      const allOf = Array.isArray(config.allOf) ? [...config.allOf] : [];
+      allOf.push({ event, fromEntity: sourceNodeId });
+      config.allOf = allOf;
+      changed = true;
+    }
+  }
+
+  // audio_emitter: set triggerEvent or stopEvent
+  if (hook.type === "audio_emitter") {
+    if (!config.triggerEvent || config.triggerEvent === event) {
+      config.triggerEvent = event;
+      changed = true;
+    } else if (!config.stopEvent || config.stopEvent === event) {
+      config.stopEvent = event;
+      changed = true;
+    }
+  }
+
+  // vfx_emitter: add event to eventMap
+  if (hook.type === "vfx_emitter") {
+    const existing = isGameplayObject(config.eventMap) ? config.eventMap : {};
+    if (!(event in existing)) {
+      config.eventMap = { ...existing, [event]: "" };
+      changed = true;
+    }
+  }
+
+  if (!changed) return null;
+
+  const beforeHooks = structuredClone(owner.hooks);
+  const hooks = owner.hooks.map((h) => (h.id === hook.id ? { ...h, config } : h));
+  return { ownerId: owner.id, ownerKind: owner.kind, hooks, beforeHooks };
+}
+
+/**
+ * Try to set `target` on a dynamic emit port of the source hook.
+ */
+function tryBindEmit(owner: Owner, hook: SceneHook, event: string, targetNodeId: string): ConnectionMutation | null {
+  const config = structuredClone(hook.config);
+  let changed = false;
+
+  // sequence / condition_listener: find an emit action with matching event → set target
+  if (hook.type === "sequence" || hook.type === "condition_listener") {
+    for (const action of toObjectArray(config.actions)) {
+      if (action.type === "emit" && action.event === event && !action.target) {
+        action.target = targetNodeId;
+        changed = true;
+        break;
+      }
+    }
+
+    // If no matching action found, add one
+    if (!changed) {
+      const actions = Array.isArray(config.actions) ? [...config.actions] : [];
+      actions.push({ type: "emit", event, target: targetNodeId, payload: null });
+      config.actions = actions;
+      changed = true;
+    }
+  }
+
+  if (!changed) return null;
+
+  const beforeHooks = structuredClone(owner.hooks);
+  const hooks = owner.hooks.map((h) => (h.id === hook.id ? { ...h, config } : h));
+  return { ownerId: owner.id, ownerKind: owner.kind, hooks, beforeHooks };
+}
+
+/**
+ * Create a new sequence hook on the source owner that bridges
+ * sourceEvent → targetEvent on targetNodeId.
+ */
+function createBridgeSequence(
+  owner: Owner,
+  sourceNodeId: string,
+  sourceEvent: string,
+  targetNodeId: string,
+  targetEvent: string
+): ConnectionMutation {
+  const newHook: SceneHook = {
+    id: createGameplayId("hook:sequence"),
+    type: "sequence",
+    enabled: true,
+    config: {
+      trigger: {
+        event: sourceEvent,
+        fromEntity: sourceNodeId,
+        once: false
+      },
+      actions: [
+        {
+          type: "emit",
+          event: targetEvent,
+          target: targetNodeId,
+          payload: null
+        }
+      ]
+    }
+  };
+
+  const beforeHooks = structuredClone(owner.hooks);
+  return {
+    ownerId: owner.id,
+    ownerKind: owner.kind,
+    hooks: [...owner.hooks, newHook],
+    beforeHooks
+  };
+}

--- a/apps/editor/src/components/editor-shell/logic-viewer/logic-graph.ts
+++ b/apps/editor/src/components/editor-shell/logic-viewer/logic-graph.ts
@@ -1,0 +1,296 @@
+import type { Entity, GameplayObject, GeometryNode } from "@ggez/shared";
+import { HOOK_DEFINITION_MAP, isGameplayObject, toObjectArray } from "@/lib/gameplay";
+import type { LogicCluster, LogicGraph, LogicGraphEdge, LogicGraphHook, LogicGraphNode } from "./types";
+
+type PortEntry = {
+  nodeId: string;
+  hookId: string;
+  direction: "emit" | "listen";
+  targetId?: string;
+};
+
+function extractDynamicPorts(hook: { id: string; type: string; config: GameplayObject }) {
+  if (!hook.config) return { dynamicEmits: [] as Array<{ event: string; targetId?: string }>, dynamicListens: [] as Array<{ event: string; sourceId?: string }> };
+
+  const dynamicEmits: Array<{ event: string; targetId?: string }> = [];
+  const dynamicListens: Array<{ event: string; sourceId?: string }> = [];
+
+  if (hook.type === "sequence") {
+    const trigger = hook.config.trigger;
+    if (isGameplayObject(trigger) && typeof trigger.event === "string" && trigger.event) {
+      dynamicListens.push({
+        event: trigger.event,
+        sourceId: typeof trigger.fromEntity === "string" ? trigger.fromEntity : undefined
+      });
+    }
+
+    for (const action of toObjectArray(hook.config.actions)) {
+      if (action.type === "emit" && typeof action.event === "string" && action.event) {
+        dynamicEmits.push({
+          event: action.event,
+          targetId: typeof action.target === "string" ? action.target : undefined
+        });
+      }
+    }
+  }
+
+  if (hook.type === "condition_listener") {
+    for (const cond of toObjectArray(hook.config.allOf)) {
+      if (typeof cond.event === "string" && cond.event) {
+        dynamicListens.push({
+          event: cond.event,
+          sourceId: typeof cond.fromEntity === "string" ? cond.fromEntity : undefined
+        });
+      }
+    }
+    for (const cond of toObjectArray(hook.config.anyOf)) {
+      if (typeof cond.event === "string" && cond.event) {
+        dynamicListens.push({
+          event: cond.event,
+          sourceId: typeof cond.fromEntity === "string" ? cond.fromEntity : undefined
+        });
+      }
+    }
+
+    for (const action of toObjectArray(hook.config.actions)) {
+      if (action.type === "emit" && typeof action.event === "string" && action.event) {
+        dynamicEmits.push({
+          event: action.event,
+          targetId: typeof action.target === "string" ? action.target : undefined
+        });
+      }
+    }
+  }
+
+  if (hook.type === "audio_emitter") {
+    if (typeof hook.config.triggerEvent === "string" && hook.config.triggerEvent) {
+      dynamicListens.push({ event: hook.config.triggerEvent });
+    }
+    if (typeof hook.config.stopEvent === "string" && hook.config.stopEvent) {
+      dynamicListens.push({ event: hook.config.stopEvent });
+    }
+  }
+
+  if (hook.type === "vfx_emitter") {
+    const eventMap = hook.config.eventMap;
+    if (isGameplayObject(eventMap)) {
+      for (const event of Object.keys(eventMap)) {
+        if (event) dynamicListens.push({ event });
+      }
+    }
+  }
+
+  return { dynamicEmits, dynamicListens };
+}
+
+function resolveEventCategory(event: string): string {
+  const prefix = event.split(".")[0];
+  const categoryMap: Record<string, string> = {
+    interact: "Interaction",
+    trigger: "Trigger",
+    lock: "State",
+    unlock: "State",
+    open: "State",
+    close: "State",
+    toggle: "State",
+    state: "State",
+    move: "Motion",
+    path: "Motion",
+    pickup: "Inventory",
+    health: "Combat",
+    damage: "Combat",
+    destroy: "Combat",
+    spawn: "Spawning",
+    spawner: "Spawning",
+    ai: "AI",
+    audio: "Feedback",
+    vfx: "Feedback",
+    flag: "Flags",
+    condition: "Logic",
+    sequence: "Logic"
+  };
+  return categoryMap[prefix] ?? "Custom";
+}
+
+export function deriveLogicGraph(
+  nodes: GeometryNode[],
+  entities: Entity[]
+): LogicGraph {
+  const graphNodes: LogicGraphNode[] = [];
+  const eventIndex = new Map<string, PortEntry[]>();
+
+  const processHooks = (
+    ownerId: string,
+    ownerLabel: string,
+    ownerKind: string,
+    hooks: NonNullable<GeometryNode["hooks"]>
+  ) => {
+    const graphHooks: LogicGraphHook[] = [];
+
+    for (const hook of hooks) {
+      const definition = HOOK_DEFINITION_MAP.get(hook.type);
+      if (!definition) continue;
+
+      const { dynamicEmits, dynamicListens } = extractDynamicPorts({
+        id: hook.id,
+        type: hook.type,
+        config: hook.config
+      });
+
+      const graphHook: LogicGraphHook = {
+        hookId: hook.id,
+        hookType: hook.type,
+        label: definition.label,
+        category: definition.category,
+        enabled: hook.enabled !== false,
+        emits: definition.emits,
+        listens: definition.listens,
+        dynamicEmits,
+        dynamicListens
+      };
+
+      graphHooks.push(graphHook);
+
+      // Index static emits
+      for (const event of definition.emits) {
+        const entries = eventIndex.get(event) ?? [];
+        entries.push({ nodeId: ownerId, hookId: hook.id, direction: "emit" });
+        eventIndex.set(event, entries);
+      }
+
+      // Index static listens
+      for (const event of definition.listens) {
+        const entries = eventIndex.get(event) ?? [];
+        entries.push({ nodeId: ownerId, hookId: hook.id, direction: "listen" });
+        eventIndex.set(event, entries);
+      }
+
+      // Index dynamic emits
+      for (const de of dynamicEmits) {
+        const entries = eventIndex.get(de.event) ?? [];
+        entries.push({ nodeId: ownerId, hookId: hook.id, direction: "emit", targetId: de.targetId });
+        eventIndex.set(de.event, entries);
+      }
+
+      // Index dynamic listens
+      for (const dl of dynamicListens) {
+        const entries = eventIndex.get(dl.event) ?? [];
+        entries.push({ nodeId: ownerId, hookId: hook.id, direction: "listen", targetId: dl.sourceId });
+        eventIndex.set(dl.event, entries);
+      }
+    }
+
+    if (graphHooks.length > 0) {
+      graphNodes.push({
+        id: ownerId,
+        label: ownerLabel,
+        kind: ownerKind,
+        hooks: graphHooks
+      });
+    }
+  };
+
+  for (const node of nodes) {
+    if (node.hooks && node.hooks.length > 0) {
+      processHooks(node.id, node.name || node.id, node.kind, node.hooks);
+    }
+  }
+
+  for (const entity of entities) {
+    if (entity.hooks && entity.hooks.length > 0) {
+      processHooks(entity.id, entity.name || entity.id, entity.type, entity.hooks);
+    }
+  }
+
+  // Build edges by connecting emitters to listeners for each event
+  const edges: LogicGraphEdge[] = [];
+  const edgeSet = new Set<string>();
+
+  for (const [event, entries] of eventIndex) {
+    const emitters = entries.filter((e) => e.direction === "emit");
+    const listeners = entries.filter((e) => e.direction === "listen");
+
+    for (const emitter of emitters) {
+      for (const listener of listeners) {
+        // Don't self-connect the same hook
+        if (emitter.nodeId === listener.nodeId && emitter.hookId === listener.hookId) continue;
+
+        // If emitter has a specific targetId, only connect to that target
+        if (emitter.targetId && emitter.targetId !== listener.nodeId) continue;
+
+        // If listener has a specific sourceId (targetId on listen side), only connect from that source
+        if (listener.targetId && listener.targetId !== emitter.nodeId) continue;
+
+        const edgeKey = `${emitter.nodeId}:${emitter.hookId}->${listener.nodeId}:${listener.hookId}@${event}`;
+        if (edgeSet.has(edgeKey)) continue;
+        edgeSet.add(edgeKey);
+
+        edges.push({
+          id: edgeKey,
+          sourceNodeId: emitter.nodeId,
+          sourceHookId: emitter.hookId,
+          targetNodeId: listener.nodeId,
+          targetHookId: listener.hookId,
+          event,
+          category: resolveEventCategory(event)
+        });
+      }
+    }
+  }
+
+  // Compute connected-component clusters via BFS
+  const adjacency = new Map<string, Set<string>>();
+  for (const n of graphNodes) adjacency.set(n.id, new Set());
+  for (const e of edges) {
+    adjacency.get(e.sourceNodeId)?.add(e.targetNodeId);
+    adjacency.get(e.targetNodeId)?.add(e.sourceNodeId);
+  }
+
+  const visited = new Set<string>();
+  const clusters: LogicCluster[] = [];
+  const nodeMap = new Map(graphNodes.map((n) => [n.id, n]));
+  let clusterIndex = 0;
+
+  for (const gn of graphNodes) {
+    if (visited.has(gn.id)) continue;
+
+    const memberIds: string[] = [];
+    const queue = [gn.id];
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (visited.has(current)) continue;
+      visited.add(current);
+      memberIds.push(current);
+      for (const neighbor of adjacency.get(current) ?? []) {
+        if (!visited.has(neighbor)) queue.push(neighbor);
+      }
+    }
+
+    // Compute dominant category
+    const categoryCounts = new Map<string, number>();
+    for (const nid of memberIds) {
+      const node = nodeMap.get(nid);
+      if (!node) continue;
+      for (const h of node.hooks) {
+        categoryCounts.set(h.category, (categoryCounts.get(h.category) ?? 0) + 1);
+      }
+    }
+
+    const sorted = [...categoryCounts.entries()].sort((a, b) => b[1] - a[1]);
+    const dominantCategory = sorted[0]?.[0] ?? "Custom";
+    const label = sorted.length > 1
+      ? `${sorted[0][0]} · ${sorted[1][0]}`
+      : sorted[0]?.[0] ?? `Group ${clusterIndex + 1}`;
+
+    clusters.push({
+      id: `cluster:${clusterIndex}`,
+      nodeIds: memberIds,
+      label,
+      dominantCategory
+    });
+    clusterIndex++;
+  }
+
+  return { nodes: graphNodes, edges, clusters };
+}

--- a/apps/editor/src/components/editor-shell/logic-viewer/logic-layout.ts
+++ b/apps/editor/src/components/editor-shell/logic-viewer/logic-layout.ts
@@ -1,0 +1,45 @@
+import dagre from "@dagrejs/dagre";
+import type { LogicGraph } from "./types";
+import { computeNodeHeight } from "./LogicNode";
+
+const NODE_WIDTH = 300;
+
+export function layoutGraph(graph: LogicGraph): Map<string, { x: number; y: number }> {
+  const g = new dagre.graphlib.Graph();
+  g.setGraph({
+    rankdir: "LR",
+    nodesep: 80,
+    ranksep: 180,
+    marginx: 60,
+    marginy: 60,
+    edgesep: 30
+  });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  for (const node of graph.nodes) {
+    const height = computeNodeHeight(node.hooks);
+    g.setNode(node.id, { width: NODE_WIDTH, height });
+  }
+
+  for (const edge of graph.edges) {
+    g.setEdge(edge.sourceNodeId, edge.targetNodeId);
+  }
+
+  dagre.layout(g);
+
+  const positions = new Map<string, { x: number; y: number }>();
+
+  for (const node of graph.nodes) {
+    const dagreNode = g.node(node.id);
+    if (dagreNode) {
+      positions.set(node.id, {
+        x: dagreNode.x - NODE_WIDTH / 2,
+        y: dagreNode.y - computeNodeHeight(node.hooks) / 2
+      });
+    }
+  }
+
+  return positions;
+}
+
+export { NODE_WIDTH };

--- a/apps/editor/src/components/editor-shell/logic-viewer/logic-theme.ts
+++ b/apps/editor/src/components/editor-shell/logic-viewer/logic-theme.ts
@@ -1,0 +1,25 @@
+const CATEGORY_COLORS: Record<string, { bg: string; border: string; text: string; edge: string }> = {
+  Interaction: { bg: "rgba(245,158,11,0.12)", border: "rgba(245,158,11,0.35)", text: "#fbbf24", edge: "#f59e0b" },
+  Trigger:     { bg: "rgba(249,115,22,0.12)", border: "rgba(249,115,22,0.35)", text: "#fb923c", edge: "#f97316" },
+  State:       { bg: "rgba(16,185,129,0.12)", border: "rgba(16,185,129,0.35)", text: "#34d399", edge: "#10b981" },
+  Motion:      { bg: "rgba(59,130,246,0.12)", border: "rgba(59,130,246,0.35)", text: "#60a5fa", edge: "#3b82f6" },
+  Inventory:   { bg: "rgba(168,85,247,0.12)", border: "rgba(168,85,247,0.35)", text: "#c084fc", edge: "#a855f7" },
+  Combat:      { bg: "rgba(239,68,68,0.12)",  border: "rgba(239,68,68,0.35)",  text: "#f87171", edge: "#ef4444" },
+  Spawning:    { bg: "rgba(236,72,153,0.12)", border: "rgba(236,72,153,0.35)", text: "#f472b6", edge: "#ec4899" },
+  AI:          { bg: "rgba(6,182,212,0.12)",   border: "rgba(6,182,212,0.35)",  text: "#22d3ee", edge: "#06b6d4" },
+  Feedback:    { bg: "rgba(139,92,246,0.12)",  border: "rgba(139,92,246,0.35)", text: "#a78bfa", edge: "#8b5cf6" },
+  Flags:       { bg: "rgba(20,184,166,0.12)",  border: "rgba(20,184,166,0.35)", text: "#2dd4bf", edge: "#14b8a6" },
+  Logic:       { bg: "rgba(99,102,241,0.12)",  border: "rgba(99,102,241,0.35)", text: "#818cf8", edge: "#6366f1" },
+  Core:        { bg: "rgba(148,163,184,0.12)", border: "rgba(148,163,184,0.35)", text: "#94a3b8", edge: "#64748b" },
+  Custom:      { bg: "rgba(148,163,184,0.12)", border: "rgba(148,163,184,0.35)", text: "#94a3b8", edge: "#64748b" }
+};
+
+const DEFAULT_COLOR = { bg: "rgba(148,163,184,0.12)", border: "rgba(148,163,184,0.35)", text: "#94a3b8", edge: "#64748b" };
+
+export function getCategoryColor(category: string) {
+  return CATEGORY_COLORS[category] ?? DEFAULT_COLOR;
+}
+
+export function getEdgeColor(category: string) {
+  return (CATEGORY_COLORS[category] ?? DEFAULT_COLOR).edge;
+}

--- a/apps/editor/src/components/editor-shell/logic-viewer/types.ts
+++ b/apps/editor/src/components/editor-shell/logic-viewer/types.ts
@@ -1,0 +1,41 @@
+export type LogicGraphHook = {
+  hookId: string;
+  hookType: string;
+  label: string;
+  category: string;
+  enabled: boolean;
+  emits: string[];
+  listens: string[];
+  dynamicEmits: Array<{ event: string; targetId?: string }>;
+  dynamicListens: Array<{ event: string; sourceId?: string }>;
+};
+
+export type LogicGraphNode = {
+  id: string;
+  label: string;
+  kind: string;
+  hooks: LogicGraphHook[];
+};
+
+export type LogicGraphEdge = {
+  id: string;
+  sourceNodeId: string;
+  sourceHookId: string;
+  targetNodeId: string;
+  targetHookId: string;
+  event: string;
+  category: string;
+};
+
+export type LogicCluster = {
+  id: string;
+  nodeIds: string[];
+  label: string;
+  dominantCategory: string;
+};
+
+export type LogicGraph = {
+  nodes: LogicGraphNode[];
+  edges: LogicGraphEdge[];
+  clusters: LogicCluster[];
+};

--- a/apps/editor/src/lib/gameplay.ts
+++ b/apps/editor/src/lib/gameplay.ts
@@ -761,21 +761,64 @@ const hookDefinitionEntries: Array<HookDefinition & { defaultConfig: SceneHook["
   {
     category: "Feedback",
     defaultConfig: {
-      eventMap: {
-        "open.started": "door_metal_open"
-      },
+      autoPlay: false,
+      channel: "sfx",
+      clip: "",
+      distanceModel: "inverse",
       loop: false,
-      spatial: true
+      maxDistance: 10000,
+      pitch: 1,
+      refDistance: 1,
+      rolloffFactor: 1,
+      spatial: false,
+      stopEvent: "",
+      triggerEvent: "",
+      volume: 1
     },
-    description: "Plays audio cues in response to gameplay events.",
-    emits: ["audio.started", "audio.stopped"],
+    description: "Plays audio clips in response to gameplay events with optional 3D spatial positioning.",
+    emits: ["audio.play", "audio.stop"],
     fields: [
       {
-        kind: "event-map",
-        label: "Event Map",
-        path: "eventMap",
-        valueLabel: "Audio Cue",
-        valuePlaceholder: "door_metal_open"
+        kind: "text",
+        label: "Clip",
+        path: "clip",
+        placeholder: "door_open.ogg"
+      },
+      {
+        kind: "enum",
+        label: "Channel",
+        options: [
+          { label: "SFX", value: "sfx" },
+          { label: "Music", value: "music" },
+          { label: "Ambient", value: "ambient" },
+          { label: "UI", value: "ui" },
+          { label: "Voice", value: "voice" }
+        ],
+        path: "channel"
+      },
+      {
+        kind: "number",
+        label: "Volume",
+        min: 0,
+        path: "volume",
+        step: 0.05
+      },
+      {
+        kind: "number",
+        label: "Pitch",
+        min: 0.1,
+        path: "pitch",
+        step: 0.05
+      },
+      {
+        kind: "boolean",
+        label: "Loop",
+        path: "loop"
+      },
+      {
+        kind: "boolean",
+        label: "Auto Play",
+        path: "autoPlay"
       },
       {
         kind: "boolean",
@@ -783,13 +826,55 @@ const hookDefinitionEntries: Array<HookDefinition & { defaultConfig: SceneHook["
         path: "spatial"
       },
       {
-        kind: "boolean",
-        label: "Loop",
-        path: "loop"
+        kind: "enum",
+        label: "Distance Model",
+        options: [
+          { label: "Inverse", value: "inverse" },
+          { label: "Linear", value: "linear" },
+          { label: "Exponential", value: "exponential" }
+        ],
+        path: "distanceModel",
+        showWhen: { path: "spatial", equals: true }
+      },
+      {
+        kind: "number",
+        label: "Ref Distance",
+        min: 0,
+        path: "refDistance",
+        step: 0.5,
+        showWhen: { path: "spatial", equals: true }
+      },
+      {
+        kind: "number",
+        label: "Max Distance",
+        min: 0,
+        path: "maxDistance",
+        step: 1,
+        showWhen: { path: "spatial", equals: true }
+      },
+      {
+        kind: "number",
+        label: "Rolloff Factor",
+        min: 0,
+        path: "rolloffFactor",
+        step: 0.1,
+        showWhen: { path: "spatial", equals: true }
+      },
+      {
+        kind: "text",
+        label: "Trigger Event",
+        path: "triggerEvent",
+        placeholder: "open.started"
+      },
+      {
+        kind: "text",
+        label: "Stop Event",
+        path: "stopEvent",
+        placeholder: "close.completed"
       }
     ],
     label: "Audio Emitter",
-    listens: ["audio.play", "audio.stop"],
+    listens: ["audio.play", "audio.stop", "audio.stop_all"],
     type: "audio_emitter"
   },
   {

--- a/apps/three-runtime-playground/package.json
+++ b/apps/three-runtime-playground/package.json
@@ -16,6 +16,7 @@
     "@react-three/rapier": "^2.2.0",
     "@ggez/gameplay-runtime": "workspace:*",
     "@ggez/render-pipeline": "workspace:*",
+    "@ggez/runtime-audio": "workspace:*",
     "@ggez/shared": "workspace:*",
     "@ggez/three-runtime": "workspace:*",
     "lucide-react": "^0.542.0",

--- a/apps/three-runtime-playground/src/gameplay-systems.ts
+++ b/apps/three-runtime-playground/src/gameplay-systems.ts
@@ -1,4 +1,5 @@
 import {
+  createAudioSystemDefinition,
   createMoverSystemDefinition,
   createOpenableSystemDefinition,
   createPathMoverSystemDefinition,
@@ -10,6 +11,7 @@ import {
 import type { WebHammerEngineScene } from "@ggez/three-runtime";
 
 export type PlaybackGameplaySystemsState = {
+  audio: boolean;
   mover: boolean;
   openable: boolean;
   pathMover: boolean;
@@ -41,6 +43,10 @@ export function createPlaybackGameplaySystems(
 
   if (enabledSystems.pathMover) {
     systems.push(createPathMoverSystemDefinition(createScenePathResolver(scene.settings.paths ?? [])));
+  }
+
+  if (enabledSystems.audio) {
+    systems.push(createAudioSystemDefinition());
   }
 
   return systems;

--- a/apps/three-runtime-playground/src/gameplay-systems.ts
+++ b/apps/three-runtime-playground/src/gameplay-systems.ts
@@ -1,11 +1,22 @@
 import {
+  createAiSystemDefinition,
   createAudioSystemDefinition,
+  createConditionListenerSystemDefinition,
+  createDamageSystemDefinition,
+  createDestructibleSystemDefinition,
+  createFlagSystemDefinition,
+  createHealthSystemDefinition,
+  createInteractionSystemDefinition,
+  createLockSystemDefinition,
   createMoverSystemDefinition,
   createOpenableSystemDefinition,
   createPathMoverSystemDefinition,
+  createPickupSystemDefinition,
   createScenePathResolver,
   createSequenceSystemDefinition,
+  createSpawnerSystemDefinition,
   createTriggerSystemDefinition,
+  createVfxEmitterSystemDefinition,
   type GameplayRuntimeSystemDefinition
 } from "@ggez/gameplay-runtime";
 import type { WebHammerEngineScene } from "@ggez/three-runtime";
@@ -48,6 +59,19 @@ export function createPlaybackGameplaySystems(
   if (enabledSystems.audio) {
     systems.push(createAudioSystemDefinition());
   }
+
+  // Always-on systems (no toggle — they activate based on hook presence)
+  systems.push(createInteractionSystemDefinition());
+  systems.push(createLockSystemDefinition());
+  systems.push(createPickupSystemDefinition());
+  systems.push(createHealthSystemDefinition());
+  systems.push(createDamageSystemDefinition());
+  systems.push(createSpawnerSystemDefinition());
+  systems.push(createAiSystemDefinition());
+  systems.push(createFlagSystemDefinition());
+  systems.push(createConditionListenerSystemDefinition());
+  systems.push(createDestructibleSystemDefinition());
+  systems.push(createVfxEmitterSystemDefinition());
 
   return systems;
 }

--- a/apps/three-runtime-playground/src/playback/PlaybackScene.tsx
+++ b/apps/three-runtime-playground/src/playback/PlaybackScene.tsx
@@ -54,6 +54,7 @@ export function PlaybackScene({
       />
       <group ref={worldRootRef}>
         <PlaybackWorld
+          gameplayRuntime={gameplayRuntime}
           onNodeObjectChange={onNodeObjectChange}
           onNodePhysicsBodyChange={onNodePhysicsBodyChange}
           onPlayerActorChange={onPlayerActorChange}
@@ -100,6 +101,7 @@ function PlaybackWorldSettings({
 }
 
 function PlaybackWorld({
+  gameplayRuntime,
   onNodeObjectChange,
   onNodePhysicsBodyChange,
   onPlayerActorChange,
@@ -110,7 +112,7 @@ function PlaybackWorld({
   sceneSettings
 }: Pick<
   PlaybackSceneProps,
-  "onNodeObjectChange" | "onNodePhysicsBodyChange" | "onPlayerActorChange" | "physicsPlayback" | "physicsRevision" | "renderScene" | "resolveAssetPath" | "sceneSettings"
+  "gameplayRuntime" | "onNodeObjectChange" | "onNodePhysicsBodyChange" | "onPlayerActorChange" | "physicsPlayback" | "physicsRevision" | "renderScene" | "resolveAssetPath" | "sceneSettings"
 >) {
   const physicsActive = physicsPlayback !== "stopped" && sceneSettings.world.physicsEnabled;
   const playerSpawn = physicsActive ? renderScene.entityMarkers.find((entity) => entity.entityType === "player-spawn") : undefined;
@@ -146,6 +148,7 @@ function PlaybackWorld({
           ))}
           {playerSpawn ? (
             <RuntimePlayer
+              gameplayRuntime={gameplayRuntime}
               onActorChange={onPlayerActorChange}
               physicsPlayback={physicsPlayback}
               sceneSettings={sceneSettings}

--- a/apps/three-runtime-playground/src/playback/RuntimePlayer.tsx
+++ b/apps/three-runtime-playground/src/playback/RuntimePlayer.tsx
@@ -2,6 +2,7 @@ import { useBeforePhysicsStep, CapsuleCollider, CuboidCollider, RigidBody, type 
 import { useFrame, useThree } from "@react-three/fiber";
 import { useEffect, useMemo, useRef, type MutableRefObject } from "react";
 import { CapsuleGeometry, Group, MathUtils, Object3D, Quaternion, Vector3 } from "three";
+import type { GameplayRuntime } from "@ggez/gameplay-runtime";
 import type { DerivedEntityMarker } from "@ggez/render-pipeline";
 import { vec3, type SceneSettings } from "@ggez/shared";
 import type { PlaybackPhysicsState, PlayerActor } from "./types";
@@ -9,11 +10,13 @@ import type { PlaybackPhysicsState, PlayerActor } from "./types";
 const PHYSICS_STEP_SECONDS = 1 / 60;
 
 export function RuntimePlayer({
+  gameplayRuntime,
   onActorChange,
   physicsPlayback,
   sceneSettings,
   spawn
 }: {
+  gameplayRuntime?: GameplayRuntime;
   onActorChange?: (actor: PlayerActor | null) => void;
   physicsPlayback: PlaybackPhysicsState;
   sceneSettings: SceneSettings;
@@ -92,6 +95,24 @@ export function RuntimePlayer({
         jumpQueuedRef.current = true;
         event.preventDefault();
       }
+
+      if (
+        event.code === (sceneSettings.player.interactKey || "KeyE") &&
+        sceneSettings.player.canInteract !== false &&
+        gameplayRuntime
+      ) {
+        gameplayRuntime.getHookTargetsByType("interactable")
+          .filter((t) => t.hook.enabled !== false)
+          .forEach((t) => {
+            gameplayRuntime!.emitEvent({
+              event: "interact.requested",
+              sourceId: "player",
+              sourceKind: "system",
+              targetId: t.targetId
+            });
+          });
+        event.preventDefault();
+      }
     };
 
     const handleKeyUp = (event: KeyboardEvent) => {
@@ -115,7 +136,7 @@ export function RuntimePlayer({
       window.removeEventListener("keyup", handleKeyUp);
       window.removeEventListener("blur", handleWindowBlur);
     };
-  }, []);
+  }, [gameplayRuntime, sceneSettings.player.interactKey, sceneSettings.player.canInteract]);
 
   useEffect(() => {
     const domElement = gl.domElement;

--- a/apps/three-runtime-playground/src/playground/types.ts
+++ b/apps/three-runtime-playground/src/playground/types.ts
@@ -3,6 +3,7 @@ import type { RefObject } from "react";
 export type PlaygroundPhysicsPlayback = "paused" | "running" | "stopped";
 
 export type EnabledSystemsState = {
+  audio: boolean;
   mover: boolean;
   openable: boolean;
   pathMover: boolean;

--- a/apps/three-runtime-playground/src/playground/useRuntimePlayground.ts
+++ b/apps/three-runtime-playground/src/playground/useRuntimePlayground.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createGameplayRuntime, createGameplayRuntimeSceneFromRuntimeScene } from "@ggez/gameplay-runtime";
+import { createAudioManager, type AudioManager } from "@ggez/runtime-audio";
 import {
   createWebHammerBundleAssetResolver,
   parseWebHammerEngineBundleZip,
@@ -22,6 +23,7 @@ type PlayerActor = {
 };
 
 const DEFAULT_SYSTEMS: EnabledSystemsState = {
+  audio: true,
   mover: true,
   openable: true,
   pathMover: true,
@@ -62,22 +64,74 @@ export function useRuntimePlayground() {
     bundleResolverRef.current?.dispose();
   }, []);
 
+  const audioManagerRef = useRef<AudioManager | undefined>(undefined);
+
   useEffect(() => {
+    audioManagerRef.current?.dispose();
+
+    const audioManager = createAudioManager({
+      clipResolver: async (clipId) => {
+        const url = await Promise.resolve(resolveAssetPath(clipId));
+        const response = await fetch(url);
+        return response.arrayBuffer();
+      }
+    });
+    audioManagerRef.current = audioManager;
+
     hostRef.current.reset();
     setRuntimeEvents([]);
     const unsubscribe = gameplayRuntime.onEvent((event) => {
       setRuntimeEvents((current) =>
         [`${event.event}${event.targetId ? ` -> ${event.targetId}` : ""}`, ...current].slice(0, 12)
       );
+
+      if (event.event === "audio.play") {
+        const p = event.payload as Record<string, unknown> | undefined;
+        if (p?.clip && typeof p.clip === "string") {
+          void audioManager.play({
+            channel: (p.channel as "sfx" | "music" | "ambient" | "ui" | "voice") ?? "sfx",
+            clip: p.clip as string,
+            distanceModel: (p.distanceModel as "inverse" | "linear" | "exponential") ?? "inverse",
+            id: p.hookId as string | undefined,
+            loop: p.loop === true,
+            maxDistance: typeof p.maxDistance === "number" ? p.maxDistance : 10000,
+            pitch: typeof p.pitch === "number" ? p.pitch : 1,
+            position: Array.isArray(p.position) ? { x: p.position[0], y: p.position[1], z: p.position[2] } : undefined,
+            refDistance: typeof p.refDistance === "number" ? p.refDistance : 1,
+            rolloffFactor: typeof p.rolloffFactor === "number" ? p.rolloffFactor : 1,
+            spatial: p.spatial === true,
+            volume: typeof p.volume === "number" ? p.volume : 1
+          });
+        }
+      }
+
+      if (event.event === "audio.stop") {
+        const p = event.payload as Record<string, unknown> | undefined;
+        if (p?.hookId && typeof p.hookId === "string") {
+          audioManager.stop(p.hookId);
+        }
+      }
     });
 
     gameplayRuntime.start();
 
+    // Resume AudioContext on first user gesture (browsers require this).
+    const resumeAudio = () => {
+      void audioManager.resume();
+      window.removeEventListener("pointerdown", resumeAudio);
+      window.removeEventListener("keydown", resumeAudio);
+    };
+    window.addEventListener("pointerdown", resumeAudio);
+    window.addEventListener("keydown", resumeAudio);
+
     return () => {
       unsubscribe();
       gameplayRuntime.dispose();
+      audioManager.dispose();
+      window.removeEventListener("pointerdown", resumeAudio);
+      window.removeEventListener("keydown", resumeAudio);
     };
-  }, [gameplayRuntime]);
+  }, [gameplayRuntime, resolveAssetPath]);
 
   const resetPhysics = useCallback(() => {
     setPhysicsPlayback("stopped");
@@ -104,7 +158,7 @@ export function useRuntimePlayground() {
         const text = await file.text();
         bundleResolverRef.current?.dispose();
         bundleResolverRef.current = undefined;
-        nextScene = parseWebHammerEngineScene(text);
+        nextScene = parseSceneText(text);
       }
 
       setScene(nextScene);
@@ -182,4 +236,21 @@ export function useRuntimePlayground() {
     stageStats,
     status
   };
+}
+
+/** Parse scene text — handles both runtime format and .whmap editor format. */
+function parseSceneText(text: string): WebHammerEngineScene {
+  const parsed = JSON.parse(text);
+
+  if (parsed?.format === "whmap" && parsed.scene) {
+    const scene = parsed.scene;
+    scene.metadata = {
+      exportedAt: new Date().toISOString(),
+      format: "web-hammer-engine",
+      version: 6
+    };
+    return parseWebHammerEngineScene(JSON.stringify(scene));
+  }
+
+  return parseWebHammerEngineScene(text);
 }

--- a/apps/three-runtime-playground/src/sample-scene.ts
+++ b/apps/three-runtime-playground/src/sample-scene.ts
@@ -457,10 +457,12 @@ export function createSampleScene(): WebHammerEngineScene {
       player: {
         cameraMode: "third-person",
         canCrouch: true,
+        canInteract: true,
         canJump: true,
         canRun: true,
         crouchHeight: 1.2,
         height: 1.8,
+        interactKey: "KeyE",
         jumpHeight: 1.1,
         movementSpeed: 4.5,
         runningSpeed: 7

--- a/apps/three-runtime-playground/src/sample-scene.ts
+++ b/apps/three-runtime-playground/src/sample-scene.ts
@@ -80,6 +80,20 @@ export function createSampleScene(): WebHammerEngineScene {
           uvScale: { x: 4, y: 4 }
         },
         geometry: geometryFromPrimitive(new BoxGeometry(16, 0.8, 16), floorMaterial),
+        hooks: [
+          {
+            config: {
+              autoPlay: true,
+              clip: "sample:wind",
+              loop: true,
+              spatial: false,
+              volume: 0.12
+            },
+            enabled: true,
+            id: "hook:sample:floor:wind",
+            type: "audio_emitter"
+          }
+        ],
         id: "node:sample:floor",
         kind: "primitive",
         name: "Floor",
@@ -146,6 +160,23 @@ export function createSampleScene(): WebHammerEngineScene {
             enabled: true,
             id: "hook:sample:spire:tags",
             type: "tags"
+          },
+          {
+            config: {
+              autoPlay: true,
+              clip: "sample:machinery",
+              distanceModel: "inverse",
+              loop: true,
+              maxDistance: 25,
+              pitch: 1,
+              refDistance: 2,
+              rolloffFactor: 1.5,
+              spatial: true,
+              volume: 0.3
+            },
+            enabled: true,
+            id: "hook:sample:spire:audio",
+            type: "audio_emitter"
           }
         ],
         id: "node:sample:spire-group",
@@ -219,6 +250,22 @@ export function createSampleScene(): WebHammerEngineScene {
             enabled: true,
             id: "hook:sample:door:mover",
             type: "mover"
+          },
+          {
+            config: {
+              clip: "sample:door-slide",
+              distanceModel: "inverse",
+              maxDistance: 20,
+              pitch: 1,
+              refDistance: 1,
+              rolloffFactor: 2,
+              spatial: true,
+              triggerEvent: "open.started",
+              volume: 0.8
+            },
+            enabled: true,
+            id: "hook:sample:door:audio",
+            type: "audio_emitter"
           }
         ],
         id: "node:sample:door-root",
@@ -275,6 +322,22 @@ export function createSampleScene(): WebHammerEngineScene {
             enabled: true,
             id: "hook:sample:platform:trigger",
             type: "trigger_volume"
+          },
+          {
+            config: {
+              clip: "sample:chime",
+              distanceModel: "inverse",
+              maxDistance: 30,
+              pitch: 1,
+              refDistance: 2,
+              rolloffFactor: 1,
+              spatial: true,
+              triggerEvent: "trigger.enter",
+              volume: 0.5
+            },
+            enabled: true,
+            id: "hook:sample:platform:audio",
+            type: "audio_emitter"
           },
           {
             config: {
@@ -431,12 +494,43 @@ export function createSampleScene(): WebHammerEngineScene {
   };
 }
 
+const sampleAudioCache = new Map<string, string>();
+
 export async function resolveSampleAssetPath(path: string) {
   if (path === SAMPLE_MODEL_PATH) {
     return createSampleGltfDataUrl();
   }
 
+  if (path.startsWith("sample:")) {
+    const cached = sampleAudioCache.get(path);
+    if (cached) return cached;
+
+    const url = generateSampleAudio(path);
+    if (url) {
+      sampleAudioCache.set(path, url);
+      return url;
+    }
+  }
+
   return path;
+}
+
+function generateSampleAudio(clipId: string): string | undefined {
+  switch (clipId) {
+    case "sample:wind":          return generateWind(4, 0.25);
+    case "sample:rain":          return generateRain(3, 0.2);
+    case "sample:water-stream":  return generateWaterStream(3, 0.2);
+    case "sample:ambient-hum":   return generateHum(2, 0.15, 90);
+    case "sample:machinery":     return generateHum(3, 0.2, 60);
+    case "sample:door-slide":    return generateSweep(140, 80, 0.6, 0.3);
+    case "sample:chime":         return generateChime(880, 1.2, 0.35);
+    case "sample:footstep":      return generateImpact(60, 0.08, 0.4);
+    case "sample:click":         return generateImpact(2000, 0.025, 0.3);
+    case "sample:alarm":         return generateSweep(600, 1200, 1.5, 0.2);
+    case "sample:explosion":     return generateExplosion(1.2, 0.4);
+    case "sample:pickup":        return generatePickup(0.4, 0.3);
+    default:                     return undefined;
+  }
 }
 
 function geometryFromPrimitive(geometry: BufferGeometry, material: WebHammerExportMaterial) {
@@ -621,4 +715,263 @@ function toBase64(bytes: Uint8Array) {
     binary += String.fromCharCode(value);
   });
   return btoa(binary);
+}
+
+// ---------------------------------------------------------------------------
+//  Procedural audio generators — all produce mono 16-bit WAV data URLs.
+// ---------------------------------------------------------------------------
+
+const SAMPLE_RATE = 22050;
+
+function encodeWav(samples: Float32Array): string {
+  const numSamples = samples.length;
+  const dataSize = numSamples * 2;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  writeString(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeString(view, 8, "WAVE");
+  writeString(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, SAMPLE_RATE, true);
+  view.setUint32(28, SAMPLE_RATE * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeString(view, 36, "data");
+  view.setUint32(40, dataSize, true);
+
+  for (let i = 0; i < numSamples; i++) {
+    view.setInt16(44 + i * 2, Math.max(-32768, Math.min(32767, Math.round(samples[i] * 32767))), true);
+  }
+
+  return `data:audio/wav;base64,${toBase64(new Uint8Array(buffer))}`;
+}
+
+function writeString(view: DataView, offset: number, value: string) {
+  for (let i = 0; i < value.length; i++) {
+    view.setUint8(offset + i, value.charCodeAt(i));
+  }
+}
+
+function fade(i: number, total: number, fadeMs = 20): number {
+  const fadeSamples = (SAMPLE_RATE * fadeMs) / 1000;
+  return Math.min(1, i / fadeSamples) * Math.min(1, (total - i) / fadeSamples);
+}
+
+// Seeded PRNG for deterministic noise.
+function prng(seed: number) {
+  let s = seed | 0;
+  return () => {
+    s = (s * 1103515245 + 12345) & 0x7fffffff;
+    return (s / 0x7fffffff) * 2 - 1;
+  };
+}
+
+/** Wind — layered filtered noise with slow amplitude modulation. */
+function generateWind(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(42);
+
+  // Generate raw noise then low-pass filter by averaging.
+  const raw = new Float32Array(n);
+  for (let i = 0; i < n; i++) raw[i] = noise();
+
+  // Simple moving-average low-pass (window = 60 ≈ ~370 Hz cutoff).
+  const window = 60;
+  let sum = 0;
+  for (let i = 0; i < window && i < n; i++) sum += raw[i];
+  for (let i = 0; i < n; i++) {
+    if (i >= window) sum -= raw[i - window];
+    if (i + window < n) sum += raw[i + window];
+    const filtered = sum / window;
+    // Slow modulation at ~0.3 Hz for gusts.
+    const gust = 0.5 + 0.5 * Math.sin(2 * Math.PI * 0.3 * (i / SAMPLE_RATE));
+    out[i] = filtered * amp * gust * fade(i, n, 200);
+  }
+
+  return encodeWav(out);
+}
+
+/** Rain — sparse random drops with short exponential decay. */
+function generateRain(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const rng = prng(77);
+  const dropInterval = Math.floor(SAMPLE_RATE * 0.012);
+  const decaySamples = Math.floor(SAMPLE_RATE * 0.004);
+
+  for (let i = 0; i < n; i += dropInterval) {
+    if (rng() > -0.3) {
+      const strength = 0.5 + 0.5 * Math.abs(rng());
+      for (let j = 0; j < decaySamples && i + j < n; j++) {
+        out[i + j] += rng() * amp * strength * Math.exp(-j / (decaySamples * 0.25));
+      }
+    }
+  }
+
+  // Soft low-pass.
+  for (let i = 1; i < n; i++) {
+    out[i] = out[i] * 0.6 + out[i - 1] * 0.4;
+  }
+
+  for (let i = 0; i < n; i++) out[i] *= fade(i, n, 100);
+  return encodeWav(out);
+}
+
+/** Water stream — denser noise with bandpass character. */
+function generateWaterStream(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(123);
+
+  for (let i = 0; i < n; i++) {
+    out[i] = noise();
+  }
+
+  // Bandpass: low-pass then high-pass.
+  for (let pass = 0; pass < 3; pass++) {
+    for (let i = 1; i < n; i++) {
+      out[i] = out[i] * 0.35 + out[i - 1] * 0.65;
+    }
+  }
+  // High-pass (subtract running average).
+  let avg = 0;
+  for (let i = 0; i < n; i++) {
+    avg = avg * 0.995 + out[i] * 0.005;
+    out[i] = (out[i] - avg) * amp * fade(i, n, 150);
+  }
+
+  // Add subtle bubbling — sparse higher-freq pops.
+  const rng2 = prng(456);
+  for (let i = 0; i < n; i += Math.floor(SAMPLE_RATE * 0.02)) {
+    if (rng2() > 0.4) {
+      const freq = 800 + rng2() * 600;
+      const len = Math.floor(SAMPLE_RATE * 0.008);
+      for (let j = 0; j < len && i + j < n; j++) {
+        out[i + j] += Math.sin(2 * Math.PI * freq * (j / SAMPLE_RATE)) * amp * 0.15 * Math.exp(-j / (len * 0.3));
+      }
+    }
+  }
+
+  return encodeWav(out);
+}
+
+/** Hum — rich harmonic drone (machinery, power grid). */
+function generateHum(duration: number, amp: number, baseFreq: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const harmonics = [1, 2, 3, 4, 5, 6];
+  const harmonicAmps = [1, 0.5, 0.35, 0.2, 0.12, 0.08];
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    let sample = 0;
+    for (let h = 0; h < harmonics.length; h++) {
+      sample += Math.sin(2 * Math.PI * baseFreq * harmonics[h] * t) * harmonicAmps[h];
+    }
+    // Subtle amplitude wobble.
+    const wobble = 1 + 0.08 * Math.sin(2 * Math.PI * 1.5 * t);
+    out[i] = sample * amp * wobble * fade(i, n, 80) / harmonics.length;
+  }
+
+  return encodeWav(out);
+}
+
+/** Sweep — frequency glide (door slide, alarm siren). */
+function generateSweep(startFreq: number, endFreq: number, duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    const progress = i / n;
+    const freq = startFreq + (endFreq - startFreq) * progress;
+    out[i] = Math.sin(2 * Math.PI * freq * t) * amp * fade(i, n, 15);
+  }
+
+  return encodeWav(out);
+}
+
+/** Chime — bell-like decaying tone with inharmonic partials. */
+function generateChime(freq: number, duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const partials = [1, 2.76, 5.4, 8.93];
+  const partialAmps = [1, 0.6, 0.3, 0.15];
+  const decays = [1.2, 0.8, 0.5, 0.3];
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    let sample = 0;
+    for (let p = 0; p < partials.length; p++) {
+      sample += Math.sin(2 * Math.PI * freq * partials[p] * t) * partialAmps[p] * Math.exp(-t / decays[p]);
+    }
+    out[i] = sample * amp * fade(i, n, 2) / partials.length;
+  }
+
+  return encodeWav(out);
+}
+
+/** Impact — short thud or click (footstep, UI click). */
+function generateImpact(freq: number, duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(99);
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    const env = Math.exp(-t / (duration * 0.2));
+    const tone = Math.sin(2 * Math.PI * freq * t) * 0.6;
+    const click = noise() * 0.4;
+    out[i] = (tone + click) * amp * env;
+  }
+
+  return encodeWav(out);
+}
+
+/** Explosion — noise burst with deep rumble tail. */
+function generateExplosion(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(333);
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    // Initial noise burst.
+    const burst = noise() * Math.exp(-t / 0.05);
+    // Deep rumble.
+    const rumble = Math.sin(2 * Math.PI * 35 * t) * Math.exp(-t / 0.4) * 0.6;
+    const rumble2 = Math.sin(2 * Math.PI * 55 * t) * Math.exp(-t / 0.3) * 0.3;
+    out[i] = (burst + rumble + rumble2) * amp * fade(i, n, 2);
+  }
+
+  // Low-pass the burst portion.
+  for (let i = 1; i < n; i++) {
+    out[i] = out[i] * 0.5 + out[i - 1] * 0.5;
+  }
+
+  return encodeWav(out);
+}
+
+/** Pickup — ascending chime arpeggio. */
+function generatePickup(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const notes = [523, 659, 784, 1047]; // C5, E5, G5, C6
+  const noteLen = Math.floor(n / notes.length);
+
+  for (let ni = 0; ni < notes.length; ni++) {
+    const start = ni * noteLen;
+    for (let i = 0; i < noteLen && start + i < n; i++) {
+      const t = i / SAMPLE_RATE;
+      const env = Math.exp(-t / (duration * 0.6));
+      out[start + i] += Math.sin(2 * Math.PI * notes[ni] * t) * amp * env * fade(i, noteLen, 3);
+    }
+  }
+
+  return encodeWav(out);
 }

--- a/apps/three-vanilla-playground/package.json
+++ b/apps/three-vanilla-playground/package.json
@@ -14,6 +14,7 @@
     "@dimforge/rapier3d-compat": "^0.19.2",
     "@ggez/gameplay-runtime": "workspace:*",
     "@ggez/render-pipeline": "workspace:*",
+    "@ggez/runtime-audio": "workspace:*",
     "@ggez/runtime-physics-rapier": "workspace:*",
     "@ggez/shared": "workspace:*",
     "@ggez/three-runtime": "workspace:*",

--- a/apps/three-vanilla-playground/src/app.ts
+++ b/apps/three-vanilla-playground/src/app.ts
@@ -1,4 +1,5 @@
 import { createGameplayRuntime, createGameplayRuntimeSceneFromRuntimeScene } from "@ggez/gameplay-runtime";
+import { createAudioManager, type AudioManager } from "@ggez/runtime-audio";
 import { normalizeSceneSettings } from "@ggez/shared";
 import {
   createWebHammerBundleAssetResolver,
@@ -14,6 +15,7 @@ import { createSampleScene, resolveSampleAssetPath } from "./sample-scene";
 import type { AssetPathResolver, EnabledSystemKey, EnabledSystemsState, PlaybackPhysicsState, StageStats } from "./types";
 
 const DEFAULT_SYSTEMS: EnabledSystemsState = {
+  audio: true,
   mover: true,
   openable: true,
   pathMover: true,
@@ -26,7 +28,8 @@ const SYSTEM_OPTIONS: Array<{ key: EnabledSystemKey; label: string }> = [
   { key: "sequence", label: "Sequence" },
   { key: "openable", label: "Openable" },
   { key: "mover", label: "Mover" },
-  { key: "pathMover", label: "Path Mover" }
+  { key: "pathMover", label: "Path Mover" },
+  { key: "audio", label: "Audio" }
 ];
 
 export function createRuntimePlaygroundApp(root: HTMLElement) {
@@ -40,6 +43,7 @@ class RuntimePlaygroundApp {
   private readonly root: HTMLElement;
   private readonly sceneController: PlaybackSceneController;
 
+  private audioManager?: AudioManager;
   private bundleResolver?: ReturnType<typeof createWebHammerBundleAssetResolver>;
   private drawerOpen = false;
   private enabledSystems: EnabledSystemsState = { ...DEFAULT_SYSTEMS };
@@ -55,11 +59,20 @@ class RuntimePlaygroundApp {
   constructor(root: HTMLElement) {
     this.root = root;
     this.refs = createShell(root);
-    this.fileInput.accept = ".zip,.json";
+    this.fileInput.accept = ".zip,.json,.whmap";
     this.fileInput.className = "hidden";
     this.fileInput.type = "file";
     this.fileInput.addEventListener("change", this.handleFileInput);
     this.refs.topBar.append(this.fileInput);
+
+    // Resume AudioContext on first user gesture (browsers require this).
+    const resumeAudio = () => {
+      void this.audioManager?.resume();
+      window.removeEventListener("pointerdown", resumeAudio);
+      window.removeEventListener("keydown", resumeAudio);
+    };
+    window.addEventListener("pointerdown", resumeAudio, { once: true });
+    window.addEventListener("keydown", resumeAudio, { once: true });
     this.sceneController = new PlaybackSceneController(this.refs.stage, {
       host: this.host,
       onError: (message) => {
@@ -96,19 +109,60 @@ class RuntimePlaygroundApp {
 
   private async rebuildRuntime() {
     this.gameplayRuntime?.dispose();
+    this.audioManager?.dispose();
+    this.audioManager = undefined;
+
     const renderScene = createPlaybackRenderScene(this.scene);
     const sceneSettings = normalizeSceneSettings(this.scene.settings);
+    const resolveAssetPath = this.resolveAssetPath;
     const gameplayRuntime = createGameplayRuntime({
       host: this.host.host,
       scene: createGameplayRuntimeSceneFromRuntimeScene(this.scene),
       systems: createPlaybackGameplaySystems(this.scene, this.enabledSystems)
     });
 
+    // Wire AudioManager to gameplay audio events.
+    const audioManager = createAudioManager({
+      clipResolver: async (clipId) => {
+        const url = await Promise.resolve(resolveAssetPath(clipId));
+        const response = await fetch(url);
+        return response.arrayBuffer();
+      }
+    });
+    this.audioManager = audioManager;
+
     this.host.reset();
     this.runtimeEvents = [];
     gameplayRuntime.onEvent((event) => {
       this.runtimeEvents = [`${event.event}${event.targetId ? ` -> ${event.targetId}` : ""}`, ...this.runtimeEvents].slice(0, 12);
       this.render();
+
+      if (event.event === "audio.play") {
+        const p = event.payload as Record<string, unknown> | undefined;
+        if (p?.clip && typeof p.clip === "string") {
+          void audioManager.play({
+            channel: (p.channel as "sfx" | "music" | "ambient" | "ui" | "voice") ?? "sfx",
+            clip: p.clip as string,
+            distanceModel: (p.distanceModel as "inverse" | "linear" | "exponential") ?? "inverse",
+            id: p.hookId as string | undefined,
+            loop: p.loop === true,
+            maxDistance: typeof p.maxDistance === "number" ? p.maxDistance : 10000,
+            pitch: typeof p.pitch === "number" ? p.pitch : 1,
+            position: Array.isArray(p.position) ? { x: p.position[0], y: p.position[1], z: p.position[2] } : undefined,
+            refDistance: typeof p.refDistance === "number" ? p.refDistance : 1,
+            rolloffFactor: typeof p.rolloffFactor === "number" ? p.rolloffFactor : 1,
+            spatial: p.spatial === true,
+            volume: typeof p.volume === "number" ? p.volume : 1
+          });
+        }
+      }
+
+      if (event.event === "audio.stop") {
+        const p = event.payload as Record<string, unknown> | undefined;
+        if (p?.hookId && typeof p.hookId === "string") {
+          audioManager.stop(p.hookId);
+        }
+      }
     });
     gameplayRuntime.start();
     this.gameplayRuntime = gameplayRuntime;
@@ -146,7 +200,7 @@ class RuntimePlaygroundApp {
         const text = await file.text();
         this.bundleResolver?.dispose();
         this.bundleResolver = undefined;
-        nextScene = parseWebHammerEngineScene(text);
+        nextScene = parseSceneText(text);
       }
 
       this.scene = nextScene;
@@ -444,4 +498,23 @@ function escapeHtml(value: string) {
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;");
+}
+
+/** Parse scene text — handles both runtime format and .whmap editor format. */
+function parseSceneText(text: string): WebHammerEngineScene {
+  const parsed = JSON.parse(text);
+
+  // .whmap editor format: { format: "whmap", scene: { ... } }
+  if (parsed?.format === "whmap" && parsed.scene) {
+    const scene = parsed.scene;
+    // Inject runtime metadata so parseWebHammerEngineScene accepts it.
+    scene.metadata = {
+      exportedAt: new Date().toISOString(),
+      format: "web-hammer-engine",
+      version: 6
+    };
+    return parseWebHammerEngineScene(JSON.stringify(scene));
+  }
+
+  return parseWebHammerEngineScene(text);
 }

--- a/apps/three-vanilla-playground/src/gameplay-systems.ts
+++ b/apps/three-vanilla-playground/src/gameplay-systems.ts
@@ -1,4 +1,5 @@
 import {
+  createAudioSystemDefinition,
   createMoverSystemDefinition,
   createOpenableSystemDefinition,
   createPathMoverSystemDefinition,
@@ -10,6 +11,7 @@ import {
 import type { WebHammerEngineScene } from "@ggez/three-runtime";
 
 export type PlaybackGameplaySystemsState = {
+  audio: boolean;
   mover: boolean;
   openable: boolean;
   pathMover: boolean;
@@ -41,6 +43,10 @@ export function createPlaybackGameplaySystems(
 
   if (enabledSystems.pathMover) {
     systems.push(createPathMoverSystemDefinition(createScenePathResolver(scene.settings.paths ?? [])));
+  }
+
+  if (enabledSystems.audio) {
+    systems.push(createAudioSystemDefinition());
   }
 
   return systems;

--- a/apps/three-vanilla-playground/src/gameplay-systems.ts
+++ b/apps/three-vanilla-playground/src/gameplay-systems.ts
@@ -1,11 +1,22 @@
 import {
+  createAiSystemDefinition,
   createAudioSystemDefinition,
+  createConditionListenerSystemDefinition,
+  createDamageSystemDefinition,
+  createDestructibleSystemDefinition,
+  createFlagSystemDefinition,
+  createHealthSystemDefinition,
+  createInteractionSystemDefinition,
+  createLockSystemDefinition,
   createMoverSystemDefinition,
   createOpenableSystemDefinition,
   createPathMoverSystemDefinition,
+  createPickupSystemDefinition,
   createScenePathResolver,
   createSequenceSystemDefinition,
+  createSpawnerSystemDefinition,
   createTriggerSystemDefinition,
+  createVfxEmitterSystemDefinition,
   type GameplayRuntimeSystemDefinition
 } from "@ggez/gameplay-runtime";
 import type { WebHammerEngineScene } from "@ggez/three-runtime";
@@ -48,6 +59,19 @@ export function createPlaybackGameplaySystems(
   if (enabledSystems.audio) {
     systems.push(createAudioSystemDefinition());
   }
+
+  // Always-on systems (no toggle — they activate based on hook presence)
+  systems.push(createInteractionSystemDefinition());
+  systems.push(createLockSystemDefinition());
+  systems.push(createPickupSystemDefinition());
+  systems.push(createHealthSystemDefinition());
+  systems.push(createDamageSystemDefinition());
+  systems.push(createSpawnerSystemDefinition());
+  systems.push(createAiSystemDefinition());
+  systems.push(createFlagSystemDefinition());
+  systems.push(createConditionListenerSystemDefinition());
+  systems.push(createDestructibleSystemDefinition());
+  systems.push(createVfxEmitterSystemDefinition());
 
   return systems;
 }

--- a/apps/three-vanilla-playground/src/playback/scene-controller.ts
+++ b/apps/three-vanilla-playground/src/playback/scene-controller.ts
@@ -442,6 +442,22 @@ export class PlaybackSceneController {
         cameraMode: config.cameraMode,
         domElement: this.renderer.domElement,
         onActorChange: this.options.onPlayerActorChange,
+        onInteract: () => {
+          if (!config.gameplayRuntime) {
+            return;
+          }
+
+          config.gameplayRuntime.getHookTargetsByType("interactable")
+            .filter((t) => t.hook.enabled !== false)
+            .forEach((t) => {
+              config.gameplayRuntime!.emitEvent({
+                event: "interact.requested",
+                sourceId: "player",
+                sourceKind: "system",
+                targetId: t.targetId
+              });
+            });
+        },
         sceneSettings: config.sceneSettings,
         spawnPosition: vec3(playerSpawn.position.x, playerSpawn.position.y, playerSpawn.position.z),
         spawnRotationY: playerSpawn.rotation.y,
@@ -1188,6 +1204,7 @@ type RuntimePlayerControllerOptions = {
   cameraMode: SceneRuntimeConfig["cameraMode"];
   domElement: HTMLCanvasElement;
   onActorChange?: (actor: PlayerActor | null) => void;
+  onInteract?: () => void;
   sceneSettings: SceneRuntimeConfig["sceneSettings"];
   spawnPosition: { x: number; y: number; z: number };
   spawnRotationY: number;
@@ -1203,6 +1220,7 @@ class RuntimePlayerController {
   private readonly footOffset: number;
   private readonly halfHeight: number;
   private readonly onActorChange?: (actor: PlayerActor | null) => void;
+  private readonly onInteract?: () => void;
   private readonly radius: number;
   private readonly sceneSettings: SceneRuntimeConfig["sceneSettings"];
   private readonly standingHeight: number;
@@ -1238,6 +1256,7 @@ class RuntimePlayerController {
     this.cameraMode = options.cameraMode;
     this.domElement = options.domElement;
     this.onActorChange = options.onActorChange;
+    this.onInteract = options.onInteract;
     this.sceneSettings = options.sceneSettings;
     this.world = options.world;
     this.standingHeight = Math.max(1.2, options.sceneSettings.player.height);
@@ -1518,6 +1537,14 @@ class RuntimePlayerController {
       publishVanillaDebug("jump-input", {
         pointerLocked: this.pointerLocked
       });
+      event.preventDefault();
+    }
+
+    if (
+      event.code === (this.sceneSettings.player.interactKey || "KeyE") &&
+      this.sceneSettings.player.canInteract !== false
+    ) {
+      this.onInteract?.();
       event.preventDefault();
     }
   };

--- a/apps/three-vanilla-playground/src/sample-scene.ts
+++ b/apps/three-vanilla-playground/src/sample-scene.ts
@@ -457,10 +457,12 @@ export function createSampleScene(): WebHammerEngineScene {
       player: {
         cameraMode: "third-person",
         canCrouch: true,
+        canInteract: true,
         canJump: true,
         canRun: true,
         crouchHeight: 1.2,
         height: 1.8,
+        interactKey: "KeyE",
         jumpHeight: 1.1,
         movementSpeed: 4.5,
         runningSpeed: 7

--- a/apps/three-vanilla-playground/src/sample-scene.ts
+++ b/apps/three-vanilla-playground/src/sample-scene.ts
@@ -80,6 +80,20 @@ export function createSampleScene(): WebHammerEngineScene {
           uvScale: { x: 4, y: 4 }
         },
         geometry: geometryFromPrimitive(new BoxGeometry(16, 0.8, 16), floorMaterial),
+        hooks: [
+          {
+            config: {
+              autoPlay: true,
+              clip: "sample:wind",
+              loop: true,
+              spatial: false,
+              volume: 0.12
+            },
+            enabled: true,
+            id: "hook:sample:floor:wind",
+            type: "audio_emitter"
+          }
+        ],
         id: "node:sample:floor",
         kind: "primitive",
         name: "Floor",
@@ -146,6 +160,23 @@ export function createSampleScene(): WebHammerEngineScene {
             enabled: true,
             id: "hook:sample:spire:tags",
             type: "tags"
+          },
+          {
+            config: {
+              autoPlay: true,
+              clip: "sample:machinery",
+              distanceModel: "inverse",
+              loop: true,
+              maxDistance: 25,
+              pitch: 1,
+              refDistance: 2,
+              rolloffFactor: 1.5,
+              spatial: true,
+              volume: 0.3
+            },
+            enabled: true,
+            id: "hook:sample:spire:audio",
+            type: "audio_emitter"
           }
         ],
         id: "node:sample:spire-group",
@@ -219,6 +250,22 @@ export function createSampleScene(): WebHammerEngineScene {
             enabled: true,
             id: "hook:sample:door:mover",
             type: "mover"
+          },
+          {
+            config: {
+              clip: "sample:door-slide",
+              distanceModel: "inverse",
+              maxDistance: 20,
+              pitch: 1,
+              refDistance: 1,
+              rolloffFactor: 2,
+              spatial: true,
+              triggerEvent: "open.started",
+              volume: 0.8
+            },
+            enabled: true,
+            id: "hook:sample:door:audio",
+            type: "audio_emitter"
           }
         ],
         id: "node:sample:door-root",
@@ -275,6 +322,22 @@ export function createSampleScene(): WebHammerEngineScene {
             enabled: true,
             id: "hook:sample:platform:trigger",
             type: "trigger_volume"
+          },
+          {
+            config: {
+              clip: "sample:chime",
+              distanceModel: "inverse",
+              maxDistance: 30,
+              pitch: 1,
+              refDistance: 2,
+              rolloffFactor: 1,
+              spatial: true,
+              triggerEvent: "trigger.enter",
+              volume: 0.5
+            },
+            enabled: true,
+            id: "hook:sample:platform:audio",
+            type: "audio_emitter"
           },
           {
             config: {
@@ -431,12 +494,43 @@ export function createSampleScene(): WebHammerEngineScene {
   };
 }
 
+const sampleAudioCache = new Map<string, string>();
+
 export async function resolveSampleAssetPath(path: string) {
   if (path === SAMPLE_MODEL_PATH) {
     return createSampleGltfDataUrl();
   }
 
+  if (path.startsWith("sample:")) {
+    const cached = sampleAudioCache.get(path);
+    if (cached) return cached;
+
+    const url = generateSampleAudio(path);
+    if (url) {
+      sampleAudioCache.set(path, url);
+      return url;
+    }
+  }
+
   return path;
+}
+
+function generateSampleAudio(clipId: string): string | undefined {
+  switch (clipId) {
+    case "sample:wind":          return generateWind(4, 0.25);
+    case "sample:rain":          return generateRain(3, 0.2);
+    case "sample:water-stream":  return generateWaterStream(3, 0.2);
+    case "sample:ambient-hum":   return generateHum(2, 0.15, 90);
+    case "sample:machinery":     return generateHum(3, 0.2, 60);
+    case "sample:door-slide":    return generateSweep(140, 80, 0.6, 0.3);
+    case "sample:chime":         return generateChime(880, 1.2, 0.35);
+    case "sample:footstep":      return generateImpact(60, 0.08, 0.4);
+    case "sample:click":         return generateImpact(2000, 0.025, 0.3);
+    case "sample:alarm":         return generateSweep(600, 1200, 1.5, 0.2);
+    case "sample:explosion":     return generateExplosion(1.2, 0.4);
+    case "sample:pickup":        return generatePickup(0.4, 0.3);
+    default:                     return undefined;
+  }
 }
 
 function geometryFromPrimitive(geometry: BufferGeometry, material: WebHammerExportMaterial) {
@@ -621,4 +715,263 @@ function toBase64(bytes: Uint8Array) {
     binary += String.fromCharCode(value);
   });
   return btoa(binary);
+}
+
+// ---------------------------------------------------------------------------
+//  Procedural audio generators — all produce mono 16-bit WAV data URLs.
+// ---------------------------------------------------------------------------
+
+const SAMPLE_RATE = 22050;
+
+function encodeWav(samples: Float32Array): string {
+  const numSamples = samples.length;
+  const dataSize = numSamples * 2;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  writeString(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeString(view, 8, "WAVE");
+  writeString(view, 12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, SAMPLE_RATE, true);
+  view.setUint32(28, SAMPLE_RATE * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeString(view, 36, "data");
+  view.setUint32(40, dataSize, true);
+
+  for (let i = 0; i < numSamples; i++) {
+    view.setInt16(44 + i * 2, Math.max(-32768, Math.min(32767, Math.round(samples[i] * 32767))), true);
+  }
+
+  return `data:audio/wav;base64,${toBase64(new Uint8Array(buffer))}`;
+}
+
+function writeString(view: DataView, offset: number, value: string) {
+  for (let i = 0; i < value.length; i++) {
+    view.setUint8(offset + i, value.charCodeAt(i));
+  }
+}
+
+function fade(i: number, total: number, fadeMs = 20): number {
+  const fadeSamples = (SAMPLE_RATE * fadeMs) / 1000;
+  return Math.min(1, i / fadeSamples) * Math.min(1, (total - i) / fadeSamples);
+}
+
+// Seeded PRNG for deterministic noise.
+function prng(seed: number) {
+  let s = seed | 0;
+  return () => {
+    s = (s * 1103515245 + 12345) & 0x7fffffff;
+    return (s / 0x7fffffff) * 2 - 1;
+  };
+}
+
+/** Wind — layered filtered noise with slow amplitude modulation. */
+function generateWind(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(42);
+
+  // Generate raw noise then low-pass filter by averaging.
+  const raw = new Float32Array(n);
+  for (let i = 0; i < n; i++) raw[i] = noise();
+
+  // Simple moving-average low-pass (window = 60 ≈ ~370 Hz cutoff).
+  const window = 60;
+  let sum = 0;
+  for (let i = 0; i < window && i < n; i++) sum += raw[i];
+  for (let i = 0; i < n; i++) {
+    if (i >= window) sum -= raw[i - window];
+    if (i + window < n) sum += raw[i + window];
+    const filtered = sum / window;
+    // Slow modulation at ~0.3 Hz for gusts.
+    const gust = 0.5 + 0.5 * Math.sin(2 * Math.PI * 0.3 * (i / SAMPLE_RATE));
+    out[i] = filtered * amp * gust * fade(i, n, 200);
+  }
+
+  return encodeWav(out);
+}
+
+/** Rain — sparse random drops with short exponential decay. */
+function generateRain(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const rng = prng(77);
+  const dropInterval = Math.floor(SAMPLE_RATE * 0.012);
+  const decaySamples = Math.floor(SAMPLE_RATE * 0.004);
+
+  for (let i = 0; i < n; i += dropInterval) {
+    if (rng() > -0.3) {
+      const strength = 0.5 + 0.5 * Math.abs(rng());
+      for (let j = 0; j < decaySamples && i + j < n; j++) {
+        out[i + j] += rng() * amp * strength * Math.exp(-j / (decaySamples * 0.25));
+      }
+    }
+  }
+
+  // Soft low-pass.
+  for (let i = 1; i < n; i++) {
+    out[i] = out[i] * 0.6 + out[i - 1] * 0.4;
+  }
+
+  for (let i = 0; i < n; i++) out[i] *= fade(i, n, 100);
+  return encodeWav(out);
+}
+
+/** Water stream — denser noise with bandpass character. */
+function generateWaterStream(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(123);
+
+  for (let i = 0; i < n; i++) {
+    out[i] = noise();
+  }
+
+  // Bandpass: low-pass then high-pass.
+  for (let pass = 0; pass < 3; pass++) {
+    for (let i = 1; i < n; i++) {
+      out[i] = out[i] * 0.35 + out[i - 1] * 0.65;
+    }
+  }
+  // High-pass (subtract running average).
+  let avg = 0;
+  for (let i = 0; i < n; i++) {
+    avg = avg * 0.995 + out[i] * 0.005;
+    out[i] = (out[i] - avg) * amp * fade(i, n, 150);
+  }
+
+  // Add subtle bubbling — sparse higher-freq pops.
+  const rng2 = prng(456);
+  for (let i = 0; i < n; i += Math.floor(SAMPLE_RATE * 0.02)) {
+    if (rng2() > 0.4) {
+      const freq = 800 + rng2() * 600;
+      const len = Math.floor(SAMPLE_RATE * 0.008);
+      for (let j = 0; j < len && i + j < n; j++) {
+        out[i + j] += Math.sin(2 * Math.PI * freq * (j / SAMPLE_RATE)) * amp * 0.15 * Math.exp(-j / (len * 0.3));
+      }
+    }
+  }
+
+  return encodeWav(out);
+}
+
+/** Hum — rich harmonic drone (machinery, power grid). */
+function generateHum(duration: number, amp: number, baseFreq: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const harmonics = [1, 2, 3, 4, 5, 6];
+  const harmonicAmps = [1, 0.5, 0.35, 0.2, 0.12, 0.08];
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    let sample = 0;
+    for (let h = 0; h < harmonics.length; h++) {
+      sample += Math.sin(2 * Math.PI * baseFreq * harmonics[h] * t) * harmonicAmps[h];
+    }
+    // Subtle amplitude wobble.
+    const wobble = 1 + 0.08 * Math.sin(2 * Math.PI * 1.5 * t);
+    out[i] = sample * amp * wobble * fade(i, n, 80) / harmonics.length;
+  }
+
+  return encodeWav(out);
+}
+
+/** Sweep — frequency glide (door slide, alarm siren). */
+function generateSweep(startFreq: number, endFreq: number, duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    const progress = i / n;
+    const freq = startFreq + (endFreq - startFreq) * progress;
+    out[i] = Math.sin(2 * Math.PI * freq * t) * amp * fade(i, n, 15);
+  }
+
+  return encodeWav(out);
+}
+
+/** Chime — bell-like decaying tone with inharmonic partials. */
+function generateChime(freq: number, duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const partials = [1, 2.76, 5.4, 8.93];
+  const partialAmps = [1, 0.6, 0.3, 0.15];
+  const decays = [1.2, 0.8, 0.5, 0.3];
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    let sample = 0;
+    for (let p = 0; p < partials.length; p++) {
+      sample += Math.sin(2 * Math.PI * freq * partials[p] * t) * partialAmps[p] * Math.exp(-t / decays[p]);
+    }
+    out[i] = sample * amp * fade(i, n, 2) / partials.length;
+  }
+
+  return encodeWav(out);
+}
+
+/** Impact — short thud or click (footstep, UI click). */
+function generateImpact(freq: number, duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(99);
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    const env = Math.exp(-t / (duration * 0.2));
+    const tone = Math.sin(2 * Math.PI * freq * t) * 0.6;
+    const click = noise() * 0.4;
+    out[i] = (tone + click) * amp * env;
+  }
+
+  return encodeWav(out);
+}
+
+/** Explosion — noise burst with deep rumble tail. */
+function generateExplosion(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const noise = prng(333);
+
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    // Initial noise burst.
+    const burst = noise() * Math.exp(-t / 0.05);
+    // Deep rumble.
+    const rumble = Math.sin(2 * Math.PI * 35 * t) * Math.exp(-t / 0.4) * 0.6;
+    const rumble2 = Math.sin(2 * Math.PI * 55 * t) * Math.exp(-t / 0.3) * 0.3;
+    out[i] = (burst + rumble + rumble2) * amp * fade(i, n, 2);
+  }
+
+  // Low-pass the burst portion.
+  for (let i = 1; i < n; i++) {
+    out[i] = out[i] * 0.5 + out[i - 1] * 0.5;
+  }
+
+  return encodeWav(out);
+}
+
+/** Pickup — ascending chime arpeggio. */
+function generatePickup(duration: number, amp: number): string {
+  const n = Math.floor(SAMPLE_RATE * duration);
+  const out = new Float32Array(n);
+  const notes = [523, 659, 784, 1047]; // C5, E5, G5, C6
+  const noteLen = Math.floor(n / notes.length);
+
+  for (let ni = 0; ni < notes.length; ni++) {
+    const start = ni * noteLen;
+    for (let i = 0; i < noteLen && start + i < n; i++) {
+      const t = i / SAMPLE_RATE;
+      const env = Math.exp(-t / (duration * 0.6));
+      out[start + i] += Math.sin(2 * Math.PI * notes[ni] * t) * amp * env * fade(i, noteLen, 3);
+    }
+  }
+
+  return encodeWav(out);
 }

--- a/apps/three-vanilla-playground/src/types.ts
+++ b/apps/three-vanilla-playground/src/types.ts
@@ -16,6 +16,7 @@ export type PlayerActor = {
 };
 
 export type EnabledSystemsState = {
+  audio: boolean;
   mover: boolean;
   openable: boolean;
   pathMover: boolean;

--- a/packages/gameplay-runtime/src/systems.ts
+++ b/packages/gameplay-runtime/src/systems.ts
@@ -104,7 +104,7 @@ export const GAMEPLAY_SYSTEM_BLUEPRINTS: GameplaySystemBlueprint[] = [
     description: "Routes gameplay events to audio playback.",
     hookTypes: ["audio_emitter"],
     id: "audio",
-    implemented: false,
+    implemented: true,
     label: "AudioSystem"
   },
   {
@@ -992,4 +992,105 @@ function wrapProgress(value: number) {
   }
 
   return value % 1;
+}
+
+export function createAudioSystemDefinition(): GameplayRuntimeSystemDefinition {
+  return {
+    description: "Routes gameplay events to audio playback via audio_emitter hooks.",
+    hookTypes: ["audio_emitter"],
+    id: "audio",
+    label: "AudioSystem",
+    create(context) {
+      const unsubscribes: Array<() => void> = [];
+
+      return {
+        start() {
+          context.getHookTargetsByType("audio_emitter")
+            .filter((target) => target.hook.enabled !== false)
+            .forEach((target) => {
+              const autoPlay = readBoolean(target.hook.config.autoPlay, false);
+
+              if (autoPlay) {
+                emitAudioPlay(context, target);
+              }
+
+              const triggerEvent = readString(target.hook.config.triggerEvent, "");
+
+              if (triggerEvent) {
+                const unsub = context.eventBus.subscribe(
+                  { event: triggerEvent, targetId: target.targetId },
+                  () => {
+                    if (target.hook.enabled === false) {
+                      return;
+                    }
+
+                    emitAudioPlay(context, target);
+                  }
+                );
+
+                unsubscribes.push(unsub);
+              }
+
+              const stopEvent = readString(target.hook.config.stopEvent, "");
+
+              if (stopEvent) {
+                const unsub = context.eventBus.subscribe(
+                  { event: stopEvent, targetId: target.targetId },
+                  () => {
+                    context.emitFromHookTarget(target, "audio.stop", {
+                      hookId: target.hook.id
+                    });
+                  }
+                );
+
+                unsubscribes.push(unsub);
+              }
+            });
+
+          // Global audio control events.
+          unsubscribes.push(
+            context.eventBus.subscribe({ event: "audio.stop_all" }, () => {
+              context.getHookTargetsByType("audio_emitter").forEach((target) => {
+                context.emitFromHookTarget(target, "audio.stop", {
+                  hookId: target.hook.id
+                });
+              });
+            })
+          );
+        },
+        stop() {
+          unsubscribes.forEach((unsub) => unsub());
+          unsubscribes.length = 0;
+        }
+      };
+    }
+  };
+}
+
+function emitAudioPlay(
+  context: GameplayRuntimeSystemContext,
+  target: GameplayHookTarget
+) {
+  const clip = readString(target.hook.config.clip, "");
+
+  if (!clip) {
+    return;
+  }
+
+  const worldTransform = context.getTargetWorldTransform(target.targetId);
+
+  context.emitFromHookTarget(target, "audio.play", {
+    channel: readString(target.hook.config.channel, "sfx"),
+    clip,
+    distanceModel: readString(target.hook.config.distanceModel, "inverse"),
+    hookId: target.hook.id,
+    loop: readBoolean(target.hook.config.loop, false),
+    maxDistance: readNumber(target.hook.config.maxDistance, 10000),
+    pitch: readNumber(target.hook.config.pitch, 1),
+    position: worldTransform ? [worldTransform.position.x, worldTransform.position.y, worldTransform.position.z] : null,
+    refDistance: readNumber(target.hook.config.refDistance, 1),
+    rolloffFactor: readNumber(target.hook.config.rolloffFactor, 1),
+    spatial: readBoolean(target.hook.config.spatial, false),
+    volume: readNumber(target.hook.config.volume, 1)
+  });
 }

--- a/packages/gameplay-runtime/src/systems.ts
+++ b/packages/gameplay-runtime/src/systems.ts
@@ -27,14 +27,14 @@ export const GAMEPLAY_SYSTEM_BLUEPRINTS: GameplaySystemBlueprint[] = [
     description: "Selects current interact target and emits interact.requested with actor context.",
     hookTypes: ["interactable"],
     id: "interaction",
-    implemented: false,
+    implemented: true,
     label: "InteractionSystem"
   },
   {
     description: "Evaluates keys, items, flags, and codes and emits allow or deny results.",
     hookTypes: ["lock"],
     id: "lock",
-    implemented: false,
+    implemented: true,
     label: "LockSystem"
   },
   {
@@ -62,7 +62,7 @@ export const GAMEPLAY_SYSTEM_BLUEPRINTS: GameplaySystemBlueprint[] = [
     description: "Handles pickups and grants inventory or state rewards.",
     hookTypes: ["pickup"],
     id: "pickup",
-    implemented: false,
+    implemented: true,
     label: "PickupSystem"
   },
   {
@@ -76,28 +76,28 @@ export const GAMEPLAY_SYSTEM_BLUEPRINTS: GameplaySystemBlueprint[] = [
     description: "Tracks health state and zero transitions.",
     hookTypes: ["health"],
     id: "health",
-    implemented: false,
+    implemented: true,
     label: "HealthSystem"
   },
   {
     description: "Applies damage and kill events with typed payloads.",
     hookTypes: ["damageable"],
     id: "damage",
-    implemented: false,
+    implemented: true,
     label: "DamageSystem"
   },
   {
     description: "Creates runtime entities or prefabs and enforces spawn rules.",
     hookTypes: ["spawner"],
     id: "spawner",
-    implemented: false,
+    implemented: true,
     label: "SpawnerSystem"
   },
   {
     description: "Manages AI enablement and target assignment.",
     hookTypes: ["ai_agent"],
     id: "ai",
-    implemented: false,
+    implemented: true,
     label: "AiSystem"
   },
   {
@@ -111,7 +111,7 @@ export const GAMEPLAY_SYSTEM_BLUEPRINTS: GameplaySystemBlueprint[] = [
     description: "Manages world and mission flag writes or queries.",
     hookTypes: ["flag_setter", "flag_condition"],
     id: "flag",
-    implemented: false,
+    implemented: true,
     label: "FlagSystem"
   },
   {
@@ -125,8 +125,22 @@ export const GAMEPLAY_SYSTEM_BLUEPRINTS: GameplaySystemBlueprint[] = [
     description: "Tracks allOf or anyOf event conditions and fires actions when met.",
     hookTypes: ["condition_listener"],
     id: "condition",
-    implemented: false,
+    implemented: true,
     label: "ConditionSystem"
+  },
+  {
+    description: "Handles destruction lifecycle when targets are killed or destroy-requested.",
+    hookTypes: ["destructible"],
+    id: "destructible",
+    implemented: true,
+    label: "DestructibleSystem"
+  },
+  {
+    description: "Routes gameplay events to VFX playback via vfx_emitter hooks.",
+    hookTypes: ["vfx_emitter"],
+    id: "vfx",
+    implemented: true,
+    label: "VfxEmitterSystem"
   }
 ];
 
@@ -310,6 +324,13 @@ export function createOpenableSystemDefinition(): GameplayRuntimeSystemDefinitio
           context.getHookTargetsByType("openable")
             .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
             .forEach((target) => {
+              // If target has a lock hook, only process lock-forwarded events
+              const hasLock = context.getHookTargetsByType("lock")
+                .some((lt) => lt.targetId === target.targetId && lt.hook.enabled !== false);
+              if (hasLock && readPayloadField(event.payload, "fromLock") !== true) {
+                return;
+              }
+
               const currentState = readOpenableState(
                 context.getLocalState(target.targetId, "openable:state"),
                 resolveOpenableInitialState(target.hook.config)
@@ -955,7 +976,7 @@ function readStringArray(value: GameplayValue | undefined) {
 }
 
 function readNumber(value: GameplayValue | undefined, fallback: number) {
-  return typeof value === "number" ? value : fallback;
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 
 function readBoolean(value: GameplayValue | undefined, fallback: boolean) {
@@ -987,11 +1008,7 @@ function clampProgress(value: number) {
 }
 
 function wrapProgress(value: number) {
-  if (value < 0) {
-    return 1 - (Math.abs(value) % 1);
-  }
-
-  return value % 1;
+  return ((value % 1) + 1) % 1;
 }
 
 export function createAudioSystemDefinition(): GameplayRuntimeSystemDefinition {
@@ -1093,4 +1110,1035 @@ function emitAudioPlay(
     spatial: readBoolean(target.hook.config.spatial, false),
     volume: readNumber(target.hook.config.volume, 1)
   });
+}
+
+// ---------------------------------------------------------------------------
+// InteractionSystem
+// ---------------------------------------------------------------------------
+
+export function createInteractionSystemDefinition(): GameplayRuntimeSystemDefinition {
+  return {
+    description: "Validates interact requests against range and emits started or denied events.",
+    hookTypes: ["interactable"],
+    id: "interaction",
+    label: "InteractionSystem",
+    create(context) {
+      const unsubscribe = context.eventBus.subscribe(
+        { event: "interact.requested" },
+        (event) => {
+          if (!event.targetId) {
+            return;
+          }
+
+          context.getHookTargetsByType("interactable")
+            .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+            .forEach((target) => {
+              const range = readNumber(target.hook.config.range, 3);
+              const allowedActors = readStringArray(target.hook.config.allowedActors);
+              const worldTransform = context.getTargetWorldTransform(target.targetId);
+
+              if (!worldTransform) {
+                return;
+              }
+
+              const player = context.getActors().find((actor) => {
+                const tags = actor.tags ?? [];
+
+                if (allowedActors.length > 0) {
+                  return allowedActors.some((allowed) => tags.includes(allowed));
+                }
+
+                return tags.includes("player");
+              });
+
+              if (!player) {
+                context.emitFromHookTarget(target, "interact.denied", { reason: "no_player" });
+                return;
+              }
+
+              const dist = Math.sqrt(distanceSquared(player.position, worldTransform.position));
+
+              if (dist > range) {
+                context.emitFromHookTarget(target, "interact.denied", { reason: "out_of_range", distance: dist });
+                return;
+              }
+
+              context.emitFromHookTarget(target, "interact.started", {
+                actorId: player.id,
+                prompt: readString(target.hook.config.prompt, "Interact")
+              });
+            });
+        }
+      );
+
+      return {
+        stop() {
+          unsubscribe();
+        }
+      };
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// LockSystem
+// ---------------------------------------------------------------------------
+
+export function createLockSystemDefinition(): GameplayRuntimeSystemDefinition {
+  return {
+    description: "Evaluates lock conditions and emits allow or deny results.",
+    hookTypes: ["lock"],
+    id: "lock",
+    label: "LockSystem",
+    create(context) {
+      const unsubscribe = context.eventBus.subscribe(
+        { event: ["open.requested", "unlock.requested", "toggle.requested"] },
+        (event) => {
+          if (!event.targetId) {
+            return;
+          }
+
+          // Skip events already forwarded by the lock to avoid infinite loop
+          if (readPayloadField(event.payload, "fromLock") === true) {
+            return;
+          }
+
+          context.getHookTargetsByType("lock")
+            .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+            .forEach((target) => {
+              const mode = readString(target.hook.config.mode, "key");
+              let allowed = false;
+
+              if (mode === "key") {
+                const keyId = readString(target.hook.config.keyId, "");
+                allowed = Boolean(context.getPlayerState("key:" + keyId));
+
+                if (allowed && readBoolean(target.hook.config.consumesKey, false)) {
+                  context.setPlayerState("key:" + keyId, false);
+                }
+              } else if (mode === "flag") {
+                const flag = readString(target.hook.config.flag, "");
+                const expectedValue = target.hook.config.expectedValue;
+                const currentValue = context.getWorldState(flag);
+                allowed = expectedValue !== undefined ? currentValue === expectedValue : Boolean(currentValue);
+              } else if (mode === "item") {
+                const itemId = readString(target.hook.config.itemId, "");
+                allowed = Boolean(context.getPlayerState("item:" + itemId));
+              } else if (mode === "code" || mode === "team") {
+                allowed = true;
+              }
+
+              if (allowed) {
+                context.emitFromHookTarget(target, "lock.allowed");
+
+                if (readBoolean(target.hook.config.autoUnlock, false)) {
+                  context.emitFromHookTarget(target, "lock.unlocked");
+                }
+
+                context.emitEvent({
+                  event: event.event,
+                  payload: { fromLock: true },
+                  sourceHookType: target.hook.type,
+                  sourceId: target.targetId,
+                  sourceKind: target.targetKind,
+                  targetId: target.targetId
+                });
+              } else {
+                context.emitFromHookTarget(target, "lock.denied", { mode });
+              }
+            });
+        }
+      );
+
+      return {
+        stop() {
+          unsubscribe();
+        }
+      };
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PickupSystem
+// ---------------------------------------------------------------------------
+
+export function createPickupSystemDefinition(): GameplayRuntimeSystemDefinition {
+  return {
+    description: "Handles pickups and grants inventory or state rewards.",
+    hookTypes: ["pickup"],
+    id: "pickup",
+    label: "PickupSystem",
+    create(context) {
+      const unsubscribeTrigger = context.eventBus.subscribe(
+        { event: "trigger.enter" },
+        (event) => {
+          processPickupEvent(context, event.targetId, false);
+        }
+      );
+      const unsubscribeInteract = context.eventBus.subscribe(
+        { event: "interact.started" },
+        (event) => {
+          processPickupEvent(context, event.targetId, true);
+        }
+      );
+
+      return {
+        stop() {
+          unsubscribeTrigger();
+          unsubscribeInteract();
+        }
+      };
+    }
+  };
+}
+
+function processPickupEvent(
+  context: GameplayRuntimeSystemContext,
+  targetId: string | undefined,
+  isInteraction: boolean
+) {
+  if (!targetId) {
+    return;
+  }
+
+  context.getHookTargetsByType("pickup")
+    .filter((target) => target.targetId === targetId && target.hook.enabled !== false)
+    .forEach((target) => {
+      const requiresInteract = readBoolean(target.hook.config.requiresInteract, false);
+
+      if (requiresInteract && !isInteraction) {
+        return;
+      }
+
+      if (!requiresInteract && isInteraction) {
+        return;
+      }
+
+      const grants = asObjectArray(target.hook.config.grants);
+
+      grants.forEach((grant) => {
+        const kind = readString(grant.kind, "");
+        const id = readString(grant.id, "");
+
+        if (!kind || !id) {
+          return;
+        }
+
+        if (kind === "key") {
+          context.setPlayerState("key:" + id, true);
+        } else if (kind === "item") {
+          context.setPlayerState("item:" + id, true);
+        } else if (kind === "health") {
+          const healAmount = readNumber(grant.amount, 25);
+          context.emitEvent({
+            event: "health.changed",
+            payload: { delta: healAmount, source: "pickup" },
+            sourceHookType: target.hook.type,
+            sourceId: target.targetId,
+            sourceKind: target.targetKind,
+            targetId: target.targetId
+          });
+        } else if (kind === "ammo") {
+          const current = context.getPlayerState("ammo:" + id);
+          context.setPlayerState("ammo:" + id, (typeof current === "number" ? current : 0) + 1);
+        } else if (kind === "flag") {
+          context.setWorldState(id, true);
+        }
+      });
+
+      context.emitFromHookTarget(target, "pickup.completed");
+
+      if (readBoolean(target.hook.config.consumeOnPickup, true)) {
+        target.hook.enabled = false;
+      }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// HealthSystem
+// ---------------------------------------------------------------------------
+
+export function createHealthSystemDefinition(): GameplayRuntimeSystemDefinition {
+  return {
+    description: "Tracks health state and zero transitions.",
+    hookTypes: ["health"],
+    id: "health",
+    label: "HealthSystem",
+    create(context) {
+      const unsubscribe = context.eventBus.subscribe(
+        { event: "health.changed" },
+        (event) => {
+          if (!event.targetId) {
+            return;
+          }
+
+          context.getHookTargetsByType("health")
+            .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+            .forEach((target) => {
+              const max = readNumber(target.hook.config.max, readNumber(target.hook.config.initial, 100));
+              const current = readNumber(
+                context.getLocalState(target.targetId, "health:current") as number | undefined,
+                readNumber(target.hook.config.initial, 100)
+              );
+              const delta = readNumber(readPayloadField(event.payload, "delta"), 0);
+
+              let newHealth = Math.min(max, Math.max(0, current + delta));
+
+              context.setLocalState(target.targetId, "health:current", newHealth);
+
+              if (newHealth <= 0 && current > 0) {
+                context.emitFromHookTarget(target, "health.zero");
+                context.emitFromHookTarget(target, "damage.killed");
+              }
+            });
+        }
+      );
+
+      return {
+        start() {
+          context.getHookTargetsByType("health")
+            .filter((target) => target.hook.enabled !== false)
+            .forEach((target) => {
+              const initial = readNumber(target.hook.config.initial, 100);
+              context.setLocalState(target.targetId, "health:current", initial);
+            });
+        },
+        stop() {
+          unsubscribe();
+        }
+      };
+    }
+  };
+}
+
+function readPayloadField(payload: unknown, field: string): GameplayValue | undefined {
+  if (payload && typeof payload === "object" && field in payload) {
+    return (payload as Record<string, GameplayValue>)[field];
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// DamageSystem
+// ---------------------------------------------------------------------------
+
+export function createDamageSystemDefinition(): GameplayRuntimeSystemDefinition {
+  return {
+    description: "Applies damage and kill events with typed payloads.",
+    hookTypes: ["damageable"],
+    id: "damage",
+    label: "DamageSystem",
+    create(context) {
+      const unsubscribe = context.eventBus.subscribe(
+        { event: "damage.apply" },
+        (event) => {
+          if (!event.targetId) {
+            return;
+          }
+
+          context.getHookTargetsByType("damageable")
+            .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+            .forEach((target) => {
+              const baseAmount = readNumber(readPayloadField(event.payload, "amount"), 0);
+              const damageType = readString(
+                readPayloadField(event.payload, "damageType") as string | undefined,
+                "default"
+              );
+              const multipliers = asObject(target.hook.config.multipliers);
+              const multiplier = multipliers ? readNumber(multipliers[damageType], 1) : 1;
+              const finalAmount = baseAmount * multiplier;
+
+              context.emitFromHookTarget(target, "damage.received", {
+                amount: finalAmount,
+                damageType
+              });
+
+              // Delegate health bookkeeping to HealthSystem via health.changed
+              context.emitEvent({
+                event: "health.changed",
+                payload: { delta: -finalAmount, source: "damage" },
+                sourceHookType: target.hook.type,
+                sourceId: target.targetId,
+                sourceKind: target.targetKind,
+                targetId: target.targetId
+              });
+            });
+        }
+      );
+
+      return {
+        stop() {
+          unsubscribe();
+        }
+      };
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SpawnerSystem
+// ---------------------------------------------------------------------------
+
+export function createSpawnerSystemDefinition(): GameplayRuntimeSystemDefinition {
+  return {
+    description: "Creates runtime entities or prefabs and enforces spawn rules.",
+    hookTypes: ["spawner"],
+    id: "spawner",
+    label: "SpawnerSystem",
+    create(context) {
+      const respawnTimers = new Map<string, number>();
+      const unsubscribeSpawn = context.eventBus.subscribe(
+        { event: "spawn.requested" },
+        (event) => {
+          if (!event.targetId) {
+            return;
+          }
+
+          context.getHookTargetsByType("spawner")
+            .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+            .forEach((target) => {
+              attemptSpawn(context, target);
+            });
+        }
+      );
+      const unsubscribeActivate = context.eventBus.subscribe(
+        { event: "spawner.activate" },
+        (event) => {
+          if (!event.targetId) {
+            return;
+          }
+
+          context.getHookTargetsByType("spawner")
+            .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+            .forEach((target) => {
+              context.setLocalState(target.targetId, "spawner:active", true);
+              context.emitFromHookTarget(target, "spawner.activated");
+              attemptSpawn(context, target);
+            });
+        }
+      );
+      const unsubscribeDeactivate = context.eventBus.subscribe(
+        { event: "spawner.deactivate" },
+        (event) => {
+          if (!event.targetId) {
+            return;
+          }
+
+          context.getHookTargetsByType("spawner")
+            .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+            .forEach((target) => {
+              context.setLocalState(target.targetId, "spawner:active", false);
+              context.emitFromHookTarget(target, "spawner.deactivated");
+            });
+        }
+      );
+      const unsubscribeDeath = context.eventBus.subscribe(
+        { event: ["damage.killed", "destroy.completed"] },
+        () => {
+          context.getHookTargetsByType("spawner")
+            .filter((target) => target.hook.enabled !== false)
+            .forEach((target) => {
+              const alive = readNumber(
+                context.getLocalState(target.targetId, "spawner:alive") as number | undefined,
+                0
+              );
+              if (alive > 0) {
+                context.setLocalState(target.targetId, "spawner:alive", alive - 1);
+              }
+            });
+        }
+      );
+
+      function attemptSpawn(spawnContext: GameplayRuntimeSystemContext, target: GameplayHookTarget) {
+        const maxAlive = readNumber(target.hook.config.maxAlive, Infinity);
+        const maxTotal = readNumber(target.hook.config.maxTotal, Infinity);
+        const currentCount = readNumber(
+          spawnContext.getLocalState(target.targetId, "spawner:count") as number | undefined,
+          0
+        );
+        const currentAlive = readNumber(
+          spawnContext.getLocalState(target.targetId, "spawner:alive") as number | undefined,
+          0
+        );
+
+        if (currentAlive >= maxAlive || currentCount >= maxTotal) {
+          spawnContext.emitFromHookTarget(target, "spawn.failed", { reason: "limit_reached" });
+          return;
+        }
+
+        const prefabId = readString(target.hook.config.prefabId, "");
+        spawnContext.setLocalState(target.targetId, "spawner:count", currentCount + 1);
+        spawnContext.setLocalState(target.targetId, "spawner:alive", currentAlive + 1);
+        spawnContext.emitFromHookTarget(target, "spawn.completed", { prefabId });
+
+        if (readBoolean(target.hook.config.respawn, false)) {
+          const delay = readNumber(target.hook.config.respawnDelay, 5);
+          respawnTimers.set(target.hook.id, delay);
+        }
+      }
+
+      return {
+        stop() {
+          unsubscribeSpawn();
+          unsubscribeActivate();
+          unsubscribeDeactivate();
+          unsubscribeDeath();
+          respawnTimers.clear();
+        },
+        update(deltaSeconds) {
+          respawnTimers.forEach((remaining, hookId) => {
+            const next = remaining - deltaSeconds;
+
+            if (next <= 0) {
+              respawnTimers.delete(hookId);
+
+              const target = context.getHookTargetsByType("spawner").find((t) => t.hook.id === hookId);
+
+              if (target && target.hook.enabled !== false) {
+                const active = context.getLocalState(target.targetId, "spawner:active");
+
+                if (active !== false) {
+                  attemptSpawn(context, target);
+                }
+              }
+            } else {
+              respawnTimers.set(hookId, next);
+            }
+          });
+        }
+      };
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AiSystem
+// ---------------------------------------------------------------------------
+
+export function createAiSystemDefinition(): GameplayRuntimeSystemDefinition {
+  return {
+    description: "Manages AI enablement and target assignment.",
+    hookTypes: ["ai_agent"],
+    id: "ai",
+    label: "AiSystem",
+    create(context) {
+      const unsubscribeEnable = context.eventBus.subscribe(
+        { event: "ai.enable" },
+        (event) => {
+          if (!event.targetId) {
+            return;
+          }
+
+          context.getHookTargetsByType("ai_agent")
+            .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+            .forEach((target) => {
+              context.setLocalState(target.targetId, "ai:active", true);
+              context.emitFromHookTarget(target, "ai.enabled");
+            });
+        }
+      );
+      const unsubscribeDisable = context.eventBus.subscribe(
+        { event: "ai.disable" },
+        (event) => {
+          if (!event.targetId) {
+            return;
+          }
+
+          context.getHookTargetsByType("ai_agent")
+            .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+            .forEach((target) => {
+              context.setLocalState(target.targetId, "ai:active", false);
+              context.emitFromHookTarget(target, "ai.disabled");
+            });
+        }
+      );
+      const unsubscribeSetTarget = context.eventBus.subscribe(
+        { event: "ai.set_target" },
+        (event) => {
+          if (!event.targetId) {
+            return;
+          }
+
+          context.getHookTargetsByType("ai_agent")
+            .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+            .forEach((target) => {
+              const aiTarget = readString(
+                readPayloadField(event.payload, "target") as string | undefined,
+                ""
+              );
+              context.setLocalState(target.targetId, "ai:target", aiTarget);
+              context.emitFromHookTarget(target, "ai.target_acquired", { target: aiTarget });
+            });
+        }
+      );
+
+      return {
+        start() {
+          context.getHookTargetsByType("ai_agent")
+            .filter((target) => target.hook.enabled !== false)
+            .forEach((target) => {
+              const enabled = readBoolean(target.hook.config.enabled, false);
+
+              if (enabled) {
+                context.setLocalState(target.targetId, "ai:active", true);
+                context.emitFromHookTarget(target, "ai.enabled");
+              }
+            });
+        },
+        stop() {
+          unsubscribeEnable();
+          unsubscribeDisable();
+          unsubscribeSetTarget();
+        }
+      };
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// FlagSystem
+// ---------------------------------------------------------------------------
+
+export function createFlagSystemDefinition(): GameplayRuntimeSystemDefinition {
+  return {
+    description: "Manages world and mission flag writes or queries.",
+    hookTypes: ["flag_setter", "flag_condition"],
+    id: "flag",
+    label: "FlagSystem",
+    create(context) {
+      const unsubscribeSet = context.eventBus.subscribe(
+        { event: "flag.set" },
+        (event) => {
+          if (!event.targetId) {
+            return;
+          }
+
+          context.getHookTargetsByType("flag_setter")
+            .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+            .forEach((target) => {
+              const flag = readString(target.hook.config.flag, "");
+
+              if (!flag) {
+                return;
+              }
+
+              const value = target.hook.config.value ?? true;
+              context.setWorldState(flag, value);
+              context.emitFromHookTarget(target, "flag.changed", { flag, value });
+            });
+        }
+      );
+      const unsubscribeCheck = context.eventBus.subscribe(
+        { event: "condition.check" },
+        (event) => {
+          if (!event.targetId) {
+            return;
+          }
+
+          context.getHookTargetsByType("flag_condition")
+            .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+            .forEach((target) => {
+              const flag = readString(target.hook.config.flag, "");
+
+              if (!flag) {
+                return;
+              }
+
+              const expected = target.hook.config.expected;
+              const current = context.getWorldState(flag);
+              const matched = expected !== undefined ? current === expected : Boolean(current);
+
+              if (matched) {
+                context.emitFromHookTarget(target, "condition.true", { flag, value: current });
+              } else {
+                context.emitFromHookTarget(target, "condition.false", { flag, value: current, expected });
+              }
+            });
+        }
+      );
+
+      return {
+        stop() {
+          unsubscribeSet();
+          unsubscribeCheck();
+        }
+      };
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ConditionListenerSystem
+// ---------------------------------------------------------------------------
+
+export function createConditionListenerSystemDefinition(): GameplayRuntimeSystemDefinition {
+  return {
+    description: "Tracks allOf or anyOf event conditions and fires actions when met.",
+    hookTypes: ["condition_listener"],
+    id: "condition",
+    label: "ConditionListenerSystem",
+    create(context) {
+      const conditionStates = new Map<string, ConditionListenerState>();
+      const unsubscribes: Array<() => void> = [];
+
+      return {
+        start() {
+          context.getHookTargetsByType("condition_listener")
+            .filter((target) => target.hook.enabled !== false)
+            .forEach((target) => {
+              const allOf = asObjectArray(target.hook.config.allOf);
+              const anyOf = asObjectArray(target.hook.config.anyOf);
+              const once = readBoolean(target.hook.config.once, false);
+
+              const state: ConditionListenerState = {
+                allOfMet: new Set<number>(),
+                anyOfMet: false,
+                fired: false
+              };
+
+              conditionStates.set(target.hook.id, state);
+
+              allOf.forEach((condition, index) => {
+                const eventName = readString(condition.event, "");
+                const fromEntity = readString(condition.fromEntity, "");
+
+                if (!eventName) {
+                  return;
+                }
+
+                const unsub = context.eventBus.subscribe(
+                  (event) => {
+                    if (event.event !== eventName) {
+                      return;
+                    }
+
+                    if (fromEntity && event.sourceId !== fromEntity) {
+                      return;
+                    }
+
+                    if (target.hook.enabled === false) {
+                      return;
+                    }
+
+                    state.allOfMet.add(index);
+                    evaluateConditionListener(context, target, state, allOf.length, anyOf.length, once);
+                  }
+                );
+
+                unsubscribes.push(unsub);
+              });
+
+              anyOf.forEach((condition) => {
+                const eventName = readString(condition.event, "");
+                const fromEntity = readString(condition.fromEntity, "");
+
+                if (!eventName) {
+                  return;
+                }
+
+                const unsub = context.eventBus.subscribe(
+                  (event) => {
+                    if (event.event !== eventName) {
+                      return;
+                    }
+
+                    if (fromEntity && event.sourceId !== fromEntity) {
+                      return;
+                    }
+
+                    if (target.hook.enabled === false) {
+                      return;
+                    }
+
+                    state.anyOfMet = true;
+                    evaluateConditionListener(context, target, state, allOf.length, anyOf.length, once);
+                  }
+                );
+
+                unsubscribes.push(unsub);
+              });
+            });
+        },
+        stop() {
+          unsubscribes.forEach((unsub) => unsub());
+          unsubscribes.length = 0;
+          conditionStates.clear();
+        }
+      };
+    }
+  };
+}
+
+type ConditionListenerState = {
+  allOfMet: Set<number>;
+  anyOfMet: boolean;
+  fired: boolean;
+};
+
+function evaluateConditionListener(
+  context: GameplayRuntimeSystemContext,
+  target: GameplayHookTarget,
+  state: ConditionListenerState,
+  allOfCount: number,
+  anyOfCount: number,
+  once: boolean
+) {
+  if (once && state.fired) {
+    return;
+  }
+
+  const allOfSatisfied = allOfCount === 0 || state.allOfMet.size >= allOfCount;
+  const anyOfSatisfied = anyOfCount === 0 || state.anyOfMet;
+
+  if (!allOfSatisfied || !anyOfSatisfied) {
+    return;
+  }
+
+  state.fired = true;
+  context.emitFromHookTarget(target, "condition.met");
+
+  const actions = asObjectArray(target.hook.config.actions);
+
+  actions.forEach((action) => {
+    executeConditionAction(context, target, action);
+  });
+
+  // Reset state for non-once conditions so they can fire again
+  if (!once) {
+    state.allOfMet.clear();
+    state.anyOfMet = false;
+    state.fired = false;
+  }
+}
+
+function executeConditionAction(
+  context: GameplayRuntimeSystemContext,
+  hookTarget: GameplayHookTarget,
+  action: GameplayObject
+) {
+  const actionType = readString(action.type, "");
+
+  if (actionType === "emit") {
+    const eventName = readString(action.event, "");
+    const targetId = readString(action.target, hookTarget.targetId);
+
+    if (!eventName) {
+      return;
+    }
+
+    context.emitEvent({
+      event: eventName,
+      payload: action.payload,
+      sourceHookType: hookTarget.hook.type,
+      sourceId: hookTarget.targetId,
+      sourceKind: hookTarget.targetKind,
+      targetId
+    });
+    return;
+  }
+
+  if (actionType === "set_flag") {
+    const flag = readString(action.flag, "");
+
+    if (!flag) {
+      return;
+    }
+
+    context.setWorldState(flag, action.value ?? null);
+    context.emitFromHookTarget(hookTarget, "flag.changed", {
+      flag,
+      value: action.value ?? null
+    });
+    return;
+  }
+
+  if (actionType === "enable" || actionType === "disable") {
+    const targetId = readString(action.target, "");
+
+    if (!targetId) {
+      return;
+    }
+
+    context.getHookTargets()
+      .filter((target) => target.targetId === targetId)
+      .forEach((target) => {
+        target.hook.enabled = actionType === "enable";
+      });
+    return;
+  }
+
+  if (actionType === "spawn") {
+    const targetId = readString(action.target, "");
+
+    if (targetId) {
+      context.emitEvent({
+        event: "spawn.requested",
+        sourceHookType: hookTarget.hook.type,
+        sourceId: hookTarget.targetId,
+        sourceKind: hookTarget.targetKind,
+        targetId
+      });
+    }
+
+    return;
+  }
+
+  if (actionType === "destroy") {
+    const targetId = readString(action.target, "");
+
+    if (targetId) {
+      context.emitEvent({
+        event: "destroy.requested",
+        sourceHookType: hookTarget.hook.type,
+        sourceId: hookTarget.targetId,
+        sourceKind: hookTarget.targetKind,
+        targetId
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DestructibleSystem
+// ---------------------------------------------------------------------------
+
+export function createDestructibleSystemDefinition(): GameplayRuntimeSystemDefinition {
+  return {
+    description: "Handles destruction lifecycle when targets are killed or destroy-requested.",
+    hookTypes: ["destructible"],
+    id: "destructible",
+    label: "DestructibleSystem",
+    create(context) {
+      const unsubscribe = context.eventBus.subscribe(
+        { event: ["damage.killed", "destroy.requested"] },
+        (event) => {
+          if (!event.targetId) {
+            return;
+          }
+
+          context.getHookTargetsByType("destructible")
+            .filter((target) => target.targetId === event.targetId && target.hook.enabled !== false)
+            .forEach((target) => {
+              context.emitFromHookTarget(target, "destroy.started");
+
+              const mode = readString(target.hook.config.mode, "disable");
+
+              if (mode === "disable") {
+                disableAllHooks(context, target.targetId);
+              } else if (mode === "spawn_prefab") {
+                const prefabId = readString(target.hook.config.destroyedPrefabId, "");
+
+                if (prefabId) {
+                  context.emitEvent({
+                    event: "spawn.requested",
+                    payload: { prefabId },
+                    sourceHookType: target.hook.type,
+                    sourceId: target.targetId,
+                    sourceKind: target.targetKind,
+                    targetId: target.targetId
+                  });
+                }
+              } else if (mode === "swap_mesh" || mode === "explode") {
+                context.emitFromHookTarget(target, `destroy.${mode}`, {
+                  prefabId: readString(target.hook.config.destroyedPrefabId, "")
+                });
+              }
+
+              if (readBoolean(target.hook.config.disableOnDestroy, true)) {
+                disableAllHooks(context, target.targetId);
+              }
+
+              context.emitFromHookTarget(target, "destroy.completed");
+            });
+        }
+      );
+
+      return {
+        stop() {
+          unsubscribe();
+        }
+      };
+    }
+  };
+}
+
+function disableAllHooks(context: GameplayRuntimeSystemContext, targetId: string) {
+  context.getHookTargets()
+    .filter((target) => target.targetId === targetId)
+    .forEach((target) => {
+      target.hook.enabled = false;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// VfxEmitterSystem
+// ---------------------------------------------------------------------------
+
+export function createVfxEmitterSystemDefinition(): GameplayRuntimeSystemDefinition {
+  return {
+    description: "Routes gameplay events to VFX playback via vfx_emitter hooks.",
+    hookTypes: ["vfx_emitter"],
+    id: "vfx",
+    label: "VfxEmitterSystem",
+    create(context) {
+      const unsubscribes: Array<() => void> = [];
+
+      return {
+        start() {
+          context.getHookTargetsByType("vfx_emitter")
+            .filter((target) => target.hook.enabled !== false)
+            .forEach((target) => {
+              const eventMap = asObject(target.hook.config.eventMap);
+
+              if (!eventMap) {
+                return;
+              }
+
+              for (const [triggerEvent, vfxId] of Object.entries(eventMap)) {
+                if (typeof vfxId !== "string" || !vfxId) {
+                  continue;
+                }
+
+                const unsub = context.eventBus.subscribe(
+                  { event: triggerEvent, targetId: target.targetId },
+                  () => {
+                    if (target.hook.enabled === false) {
+                      return;
+                    }
+
+                    const worldTransform = context.getTargetWorldTransform(target.targetId);
+
+                    context.emitFromHookTarget(target, "vfx.play", {
+                      hookId: target.hook.id,
+                      position: worldTransform
+                        ? [worldTransform.position.x, worldTransform.position.y, worldTransform.position.z]
+                        : null,
+                      vfxId
+                    });
+                  }
+                );
+
+                unsubscribes.push(unsub);
+              }
+            });
+
+          unsubscribes.push(
+            context.eventBus.subscribe({ event: "vfx.stop_all" }, () => {
+              context.getHookTargetsByType("vfx_emitter").forEach((vfxTarget) => {
+                context.emitFromHookTarget(vfxTarget, "vfx.stop", {
+                  hookId: vfxTarget.hook.id
+                });
+              });
+            })
+          );
+        },
+        stop() {
+          unsubscribes.forEach((unsub) => unsub());
+          unsubscribes.length = 0;
+        }
+      };
+    }
+  };
 }

--- a/packages/runtime-audio/package.json
+++ b/packages/runtime-audio/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@ggez/runtime-audio",
+  "version": "0.1.1",
+  "description": "Web Audio API adapter for Web Hammer runtime scenes with 3D spatial audio support.",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup --config ../../scripts/tsup.package.config.mjs",
+    "prepublishOnly": "bun run build"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vibe-stack/trident.git",
+    "directory": "packages/runtime-audio"
+  },
+  "bugs": {
+    "url": "https://github.com/vibe-stack/trident/issues"
+  },
+  "homepage": "https://github.com/vibe-stack/trident/tree/main/packages/runtime-audio",
+  "dependencies": {
+    "@ggez/runtime-format": "workspace:*",
+    "@ggez/shared": "workspace:*"
+  }
+}

--- a/packages/runtime-audio/src/audio-manager.ts
+++ b/packages/runtime-audio/src/audio-manager.ts
@@ -1,0 +1,436 @@
+import type { Vec3 } from "@ggez/shared";
+import type {
+  AudioChannel,
+  AudioClipResolver,
+  AudioManagerOptions,
+  AudioPlayOptions,
+  AudioSourceHandle,
+  AudioSourceState
+} from "./types";
+
+const CHANNELS: AudioChannel[] = ["sfx", "music", "ambient", "ui", "voice"];
+const DEFAULT_CHANNEL: AudioChannel = "sfx";
+
+/**
+ * Manages Web Audio API context, clip loading/caching, playback, 3D spatial audio,
+ * and a built-in mixer with independent channel volumes (sfx, music, ambient, ui, voice).
+ *
+ * Audio graph:  source → gainNode → [pannerNode] → channelGain → masterGain → destination
+ */
+export class AudioManager {
+  private readonly context: AudioContext;
+  private readonly masterGain: GainNode;
+  private readonly channelGains: Record<AudioChannel, GainNode>;
+  private readonly clipResolver: AudioClipResolver;
+  private readonly bufferCache = new Map<string, AudioBuffer>();
+  private readonly pendingLoads = new Map<string, Promise<AudioBuffer>>();
+  private readonly activeSources = new Map<string, AudioSourceState>();
+  private sourceSequence = 0;
+
+  constructor(options: AudioManagerOptions) {
+    this.clipResolver = options.clipResolver;
+    this.context = new AudioContext();
+    this.masterGain = this.context.createGain();
+    this.masterGain.gain.value = Math.max(0, Math.min(1, options.masterVolume ?? 1));
+    this.masterGain.connect(this.context.destination);
+
+    // Create one GainNode per channel, all feeding into masterGain.
+    this.channelGains = {} as Record<AudioChannel, GainNode>;
+    for (const channel of CHANNELS) {
+      const gain = this.context.createGain();
+      gain.gain.value = 1;
+      gain.connect(this.masterGain);
+      this.channelGains[channel] = gain;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Context lifecycle
+  // ---------------------------------------------------------------------------
+
+  /** Resume the AudioContext after a user gesture (required by browsers). */
+  async resume() {
+    if (this.context.state === "suspended") {
+      await this.context.resume();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Master volume
+  // ---------------------------------------------------------------------------
+
+  /** Master volume (0–1). Affects all channels. */
+  get masterVolume() {
+    return this.masterGain.gain.value;
+  }
+
+  set masterVolume(value: number) {
+    this.masterGain.gain.value = Math.max(0, Math.min(1, value));
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Channel mixer
+  // ---------------------------------------------------------------------------
+
+  /** Get the volume of a mixer channel (0–1). */
+  getChannelVolume(channel: AudioChannel): number {
+    return this.channelGains[channel]?.gain.value ?? 1;
+  }
+
+  /** Set the volume of a mixer channel (0–1). */
+  setChannelVolume(channel: AudioChannel, volume: number) {
+    const gain = this.channelGains[channel];
+    if (gain) {
+      gain.gain.value = Math.max(0, Math.min(1, volume));
+    }
+  }
+
+  /** Get all channel names. */
+  get channels(): readonly AudioChannel[] {
+    return CHANNELS;
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Listener (spatial audio)
+  // ---------------------------------------------------------------------------
+
+  /** Update the listener position and optional orientation for spatial audio. */
+  setListenerPosition(position: Vec3, forward?: Vec3, up?: Vec3) {
+    const listener = this.context.listener;
+
+    if (listener.positionX) {
+      listener.positionX.value = position.x;
+      listener.positionY.value = position.y;
+      listener.positionZ.value = position.z;
+    } else {
+      listener.setPosition(position.x, position.y, position.z);
+    }
+
+    if (forward && up) {
+      if (listener.forwardX) {
+        listener.forwardX.value = forward.x;
+        listener.forwardY.value = forward.y;
+        listener.forwardZ.value = forward.z;
+        listener.upX.value = up.x;
+        listener.upY.value = up.y;
+        listener.upZ.value = up.z;
+      } else {
+        listener.setOrientation(forward.x, forward.y, forward.z, up.x, up.y, up.z);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Clip loading
+  // ---------------------------------------------------------------------------
+
+  /** Load and decode a clip into the buffer cache. Deduplicates concurrent loads. */
+  async loadClip(clipId: string): Promise<AudioBuffer> {
+    const cached = this.bufferCache.get(clipId);
+    if (cached) return cached;
+
+    // Deduplicate in-flight loads for the same clip.
+    const pending = this.pendingLoads.get(clipId);
+    if (pending) return pending;
+
+    const loadPromise = (async () => {
+      try {
+        const raw = await this.clipResolver(clipId);
+        const buffer = await this.context.decodeAudioData(raw.slice(0));
+        this.bufferCache.set(clipId, buffer);
+        return buffer;
+      } catch (error) {
+        throw new Error(
+          `AudioManager: failed to load clip "${clipId}": ${error instanceof Error ? error.message : String(error)}`
+        );
+      } finally {
+        this.pendingLoads.delete(clipId);
+      }
+    })();
+
+    this.pendingLoads.set(clipId, loadPromise);
+    return loadPromise;
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Playback
+  // ---------------------------------------------------------------------------
+
+  /** Play a clip and return a handle to control the source. */
+  async play(options: AudioPlayOptions): Promise<AudioSourceHandle> {
+    await this.resume();
+
+    const buffer = await this.loadClip(options.clip);
+    const id = options.id ?? `audio:${this.sourceSequence += 1}`;
+    const channel = options.channel ?? DEFAULT_CHANNEL;
+
+    // Stop any existing source with the same id.
+    this.stopById(id);
+
+    const channelGain = this.channelGains[channel] ?? this.channelGains.sfx;
+    const gainNode = this.context.createGain();
+    gainNode.gain.value = Math.max(0, Math.min(1, options.volume ?? 1));
+
+    let pannerNode: PannerNode | undefined;
+
+    if (options.spatial) {
+      pannerNode = this.context.createPanner();
+      pannerNode.panningModel = "HRTF";
+      pannerNode.distanceModel = options.distanceModel ?? "inverse";
+      pannerNode.refDistance = options.refDistance ?? 1;
+      pannerNode.maxDistance = options.maxDistance ?? 10000;
+      pannerNode.rolloffFactor = options.rolloffFactor ?? 1;
+
+      if (options.position) {
+        pannerNode.positionX.value = options.position.x;
+        pannerNode.positionY.value = options.position.y;
+        pannerNode.positionZ.value = options.position.z;
+      }
+
+      gainNode.connect(pannerNode);
+      pannerNode.connect(channelGain);
+    } else {
+      gainNode.connect(channelGain);
+    }
+
+    const source = this.context.createBufferSource();
+    source.buffer = buffer;
+    source.loop = options.loop ?? false;
+    source.playbackRate.value = options.pitch ?? 1;
+    source.connect(gainNode);
+    source.start(0);
+
+    const state: AudioSourceState = {
+      channel,
+      clipId: options.clip,
+      gainNode,
+      id,
+      loop: options.loop ?? false,
+      pannerNode,
+      paused: false,
+      pausedAt: 0,
+      pitch: options.pitch ?? 1,
+      source,
+      spatial: options.spatial ?? false,
+      startedAt: this.context.currentTime
+    };
+
+    source.onended = () => {
+      if (!state.paused) {
+        this.cleanupSource(id);
+      }
+    };
+
+    this.activeSources.set(id, state);
+
+    return this.createHandle(id);
+  }
+
+  /** Play a one-shot clip that cannot be stopped or paused. Fire-and-forget. */
+  async playOneShot(clip: string, volume = 1, pitch = 1, channel: AudioChannel = "sfx") {
+    await this.resume();
+
+    const buffer = await this.loadClip(clip);
+    const channelGain = this.channelGains[channel] ?? this.channelGains.sfx;
+    const gainNode = this.context.createGain();
+    gainNode.gain.value = Math.max(0, Math.min(1, volume));
+    gainNode.connect(channelGain);
+
+    const source = this.context.createBufferSource();
+    source.buffer = buffer;
+    source.playbackRate.value = pitch;
+    source.connect(gainNode);
+    source.onended = () => {
+      gainNode.disconnect();
+    };
+    source.start(0);
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Source control
+  // ---------------------------------------------------------------------------
+
+  /** Get a handle for an active source by its id. */
+  getSource(id: string): AudioSourceHandle | undefined {
+    if (!this.activeSources.has(id)) {
+      return undefined;
+    }
+
+    return this.createHandle(id);
+  }
+
+  /** Stop a source by id. */
+  stop(id: string) {
+    this.stopById(id);
+  }
+
+  /** Stop all active sources. */
+  stopAll() {
+    for (const id of [...this.activeSources.keys()]) {
+      this.stopById(id);
+    }
+  }
+
+  /** Stop all active sources on a specific channel. */
+  stopChannel(channel: AudioChannel) {
+    for (const [id, state] of this.activeSources) {
+      if (state.channel === channel) {
+        this.stopById(id);
+      }
+    }
+  }
+
+  /** Pause a source by id. */
+  pause(id: string) {
+    const state = this.activeSources.get(id);
+
+    if (!state || state.paused || !state.source) {
+      return;
+    }
+
+    state.pausedAt = this.context.currentTime - state.startedAt;
+    state.paused = true;
+    state.source.onended = null;
+    state.source.stop();
+    state.source.disconnect();
+    state.source = undefined;
+  }
+
+  /** Resume a paused source by id. */
+  async resumeSource(id: string) {
+    const state = this.activeSources.get(id);
+
+    if (!state || !state.paused) {
+      return;
+    }
+
+    const buffer = this.bufferCache.get(state.clipId);
+
+    if (!buffer) {
+      return;
+    }
+
+    const source = this.context.createBufferSource();
+    source.buffer = buffer;
+    source.loop = state.loop;
+    source.playbackRate.value = state.pitch;
+    source.connect(state.gainNode);
+    source.start(0, state.pausedAt);
+
+    source.onended = () => {
+      if (!state.paused) {
+        this.cleanupSource(id);
+      }
+    };
+
+    state.source = source;
+    state.paused = false;
+    state.startedAt = this.context.currentTime - state.pausedAt;
+  }
+
+  /** Whether a source with the given id is currently active. */
+  isPlaying(id: string) {
+    const state = this.activeSources.get(id);
+    return state !== undefined && !state.paused;
+  }
+
+  /** Number of active sources. */
+  get activeSourceCount() {
+    return this.activeSources.size;
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Dispose
+  // ---------------------------------------------------------------------------
+
+  /** Dispose the AudioManager and release all resources. */
+  dispose() {
+    this.stopAll();
+    this.bufferCache.clear();
+    this.pendingLoads.clear();
+    for (const gain of Object.values(this.channelGains)) {
+      gain.disconnect();
+    }
+    this.masterGain.disconnect();
+    void this.context.close();
+  }
+
+  // ---------------------------------------------------------------------------
+  //  Private
+  // ---------------------------------------------------------------------------
+
+  private stopById(id: string) {
+    const state = this.activeSources.get(id);
+
+    if (!state) {
+      return;
+    }
+
+    if (state.source) {
+      state.source.onended = null;
+
+      try {
+        state.source.stop();
+      } catch {
+        // Already stopped.
+      }
+
+      state.source.disconnect();
+    }
+
+    this.cleanupSource(id);
+  }
+
+  private cleanupSource(id: string) {
+    const state = this.activeSources.get(id);
+
+    if (!state) {
+      return;
+    }
+
+    state.gainNode.disconnect();
+    state.pannerNode?.disconnect();
+    this.activeSources.delete(id);
+  }
+
+  private createHandle(id: string): AudioSourceHandle {
+    return {
+      id,
+      pause: () => this.pause(id),
+      resume: () => void this.resumeSource(id),
+      setPosition: (position: Vec3) => {
+        const state = this.activeSources.get(id);
+
+        if (state?.pannerNode) {
+          state.pannerNode.positionX.value = position.x;
+          state.pannerNode.positionY.value = position.y;
+          state.pannerNode.positionZ.value = position.z;
+        }
+      },
+      setPitch: (rate: number) => {
+        const state = this.activeSources.get(id);
+
+        if (state) {
+          state.pitch = rate;
+
+          if (state.source) {
+            state.source.playbackRate.value = rate;
+          }
+        }
+      },
+      setVolume: (volume: number) => {
+        const state = this.activeSources.get(id);
+
+        if (state) {
+          state.gainNode.gain.value = Math.max(0, Math.min(1, volume));
+        }
+      },
+      stop: () => this.stopById(id)
+    };
+  }
+}
+
+/** Create a new AudioManager instance. */
+export function createAudioManager(options: AudioManagerOptions): AudioManager {
+  return new AudioManager(options);
+}

--- a/packages/runtime-audio/src/descriptors.ts
+++ b/packages/runtime-audio/src/descriptors.ts
@@ -1,0 +1,96 @@
+import type { Entity, GameplayObject, GameplayValue, GeometryNode } from "@ggez/shared";
+import type { RuntimeAudioEmitterDescriptor, AudioDistanceModel } from "./types";
+
+/**
+ * Extract audio emitter descriptors from entities and nodes that have `audio_emitter` hooks.
+ * This is the audio equivalent of `getRuntimePhysicsDescriptors`.
+ */
+export function getRuntimeAudioDescriptors(scene: {
+  entities?: Array<Pick<Entity, "hooks" | "id" | "transform">>;
+  nodes?: Array<Pick<GeometryNode, "hooks" | "id" | "transform">>;
+}): RuntimeAudioEmitterDescriptor[] {
+  const descriptors: RuntimeAudioEmitterDescriptor[] = [];
+
+  scene.entities?.forEach((entity) => {
+    entity.hooks?.forEach((hook) => {
+      if (hook.type !== "audio_emitter") {
+        return;
+      }
+
+      const descriptor = resolveAudioDescriptor(hook.id, entity.id, hook.config, entity.transform.position);
+      if (descriptor) {
+        descriptors.push(descriptor);
+      }
+    });
+  });
+
+  scene.nodes?.forEach((node) => {
+    node.hooks?.forEach((hook) => {
+      if (hook.type !== "audio_emitter") {
+        return;
+      }
+
+      const descriptor = resolveAudioDescriptor(hook.id, node.id, hook.config, node.transform.position);
+      if (descriptor) {
+        descriptors.push(descriptor);
+      }
+    });
+  });
+
+  return descriptors;
+}
+
+function resolveAudioDescriptor(
+  hookId: string,
+  targetId: string,
+  config: GameplayObject,
+  position?: { x: number; y: number; z: number }
+): RuntimeAudioEmitterDescriptor | undefined {
+  const clip = readString(config.clip, "");
+
+  if (!clip) {
+    return undefined;
+  }
+
+  return {
+    autoPlay: readBoolean(config.autoPlay, false),
+    clip,
+    distanceModel: readDistanceModel(config.distanceModel),
+    hookId,
+    loop: readBoolean(config.loop, false),
+    maxDistance: readNumber(config.maxDistance, 10000),
+    pitch: readNumber(config.pitch, 1),
+    position: position ? { x: position.x, y: position.y, z: position.z } : undefined,
+    refDistance: readNumber(config.refDistance, 1),
+    rolloffFactor: readNumber(config.rolloffFactor, 1),
+    spatial: readBoolean(config.spatial, false),
+    stopEvent: readOptionalString(config.stopEvent),
+    targetId,
+    triggerEvent: readOptionalString(config.triggerEvent),
+    volume: readNumber(config.volume, 1)
+  };
+}
+
+function readString(value: GameplayValue | undefined, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function readOptionalString(value: GameplayValue | undefined): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readNumber(value: GameplayValue | undefined, fallback: number): number {
+  return typeof value === "number" ? value : fallback;
+}
+
+function readBoolean(value: GameplayValue | undefined, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function readDistanceModel(value: GameplayValue | undefined): AudioDistanceModel {
+  if (value === "linear" || value === "exponential" || value === "inverse") {
+    return value;
+  }
+
+  return "inverse";
+}

--- a/packages/runtime-audio/src/index.ts
+++ b/packages/runtime-audio/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./audio-manager";
+export * from "./descriptors";
+export * from "./presets";

--- a/packages/runtime-audio/src/presets.ts
+++ b/packages/runtime-audio/src/presets.ts
@@ -1,0 +1,212 @@
+import type { AudioPlayOptions } from "./types";
+
+/**
+ * Preset partial options that can be spread into an `AudioPlayOptions`.
+ *
+ * Usage:
+ * ```ts
+ * audioManager.play({ clip: "door_open.ogg", ...AUDIO_EMITTER_PRESETS.mechanism });
+ * audioManager.play({ clip: "rain.ogg", ...AUDIO_EMITTER_PRESETS.ambientZone, position });
+ * ```
+ */
+export type AudioEmitterPreset = Omit<AudioPlayOptions, "clip" | "id" | "position">;
+
+// ---------------------------------------------------------------------------
+//  Emitter presets — define *how* a source behaves (spatial, loop, volume…)
+// ---------------------------------------------------------------------------
+
+/** Small, localized 3D sound. Footsteps, switches, impacts. */
+const pointSource: AudioEmitterPreset = {
+  distanceModel: "inverse",
+  loop: false,
+  maxDistance: 50,
+  pitch: 1,
+  refDistance: 1,
+  rolloffFactor: 1,
+  spatial: true,
+  volume: 1
+};
+
+/** Ambient background loop, non-spatial. Wind, city noise, music bed. */
+const ambientLoop: AudioEmitterPreset = {
+  loop: true,
+  spatial: false,
+  volume: 0.4
+};
+
+/** Spatial ambient zone — audible when inside an area. Water stream, fire crackle, machinery hum. */
+const ambientZone: AudioEmitterPreset = {
+  distanceModel: "linear",
+  loop: true,
+  maxDistance: 30,
+  refDistance: 5,
+  rolloffFactor: 1,
+  spatial: true,
+  volume: 0.6
+};
+
+/** Background music track, non-spatial, looped, lower volume. */
+const music: AudioEmitterPreset = {
+  loop: true,
+  spatial: false,
+  volume: 0.3
+};
+
+/** One-shot UI feedback sound — button clicks, notifications. */
+const ui: AudioEmitterPreset = {
+  loop: false,
+  spatial: false,
+  volume: 0.7
+};
+
+/** Voice / dialogue line, non-spatial, one-shot, full volume. */
+const dialogue: AudioEmitterPreset = {
+  loop: false,
+  spatial: false,
+  volume: 1
+};
+
+/** Spatial dialogue — NPC speaking in the world. */
+const dialogue3d: AudioEmitterPreset = {
+  distanceModel: "inverse",
+  loop: false,
+  maxDistance: 30,
+  refDistance: 2,
+  rolloffFactor: 1.5,
+  spatial: true,
+  volume: 1
+};
+
+/** Close-range mechanical sound — door hinge, valve turn, lever pull. */
+const mechanism: AudioEmitterPreset = {
+  distanceModel: "inverse",
+  loop: false,
+  maxDistance: 20,
+  pitch: 1,
+  refDistance: 0.5,
+  rolloffFactor: 2,
+  spatial: true,
+  volume: 0.8
+};
+
+/** Weapon or explosion — loud, travels far. */
+const weapon: AudioEmitterPreset = {
+  distanceModel: "inverse",
+  loop: false,
+  maxDistance: 200,
+  refDistance: 5,
+  rolloffFactor: 0.8,
+  spatial: true,
+  volume: 1
+};
+
+/** Footstep — very short range, quiet. */
+const footstep: AudioEmitterPreset = {
+  distanceModel: "inverse",
+  loop: false,
+  maxDistance: 15,
+  refDistance: 0.5,
+  rolloffFactor: 2,
+  spatial: true,
+  volume: 0.5
+};
+
+/** Large environmental element — waterfall, generator, train. Audible from far away. */
+const environmental: AudioEmitterPreset = {
+  distanceModel: "linear",
+  loop: true,
+  maxDistance: 100,
+  refDistance: 10,
+  rolloffFactor: 1,
+  spatial: true,
+  volume: 0.7
+};
+
+/** Collectible pickup jingle — non-spatial, slightly pitched up. */
+const pickup: AudioEmitterPreset = {
+  loop: false,
+  pitch: 1.1,
+  spatial: false,
+  volume: 0.8
+};
+
+export const AUDIO_EMITTER_PRESETS = {
+  ambientLoop,
+  ambientZone,
+  dialogue,
+  dialogue3d,
+  environmental,
+  footstep,
+  mechanism,
+  music,
+  pickup,
+  pointSource,
+  ui,
+  weapon
+} as const;
+
+// ---------------------------------------------------------------------------
+//  Attenuation presets — spatial distance curves for different environments
+// ---------------------------------------------------------------------------
+
+export type AudioAttenuationPreset = Pick<
+  AudioPlayOptions,
+  "distanceModel" | "maxDistance" | "refDistance" | "rolloffFactor"
+>;
+
+/** Tight indoor space — sound drops off quickly. */
+const indoor: AudioAttenuationPreset = {
+  distanceModel: "inverse",
+  maxDistance: 25,
+  refDistance: 1,
+  rolloffFactor: 2.5
+};
+
+/** Standard outdoor environment — gradual falloff. */
+const outdoor: AudioAttenuationPreset = {
+  distanceModel: "inverse",
+  maxDistance: 150,
+  refDistance: 5,
+  rolloffFactor: 0.6
+};
+
+/** Large reverberant space — cathedral, warehouse, canyon. */
+const cathedral: AudioAttenuationPreset = {
+  distanceModel: "inverse",
+  maxDistance: 200,
+  refDistance: 8,
+  rolloffFactor: 0.4
+};
+
+/** Very close range — whisper, tiny mechanism, breathing. */
+const intimate: AudioAttenuationPreset = {
+  distanceModel: "exponential",
+  maxDistance: 5,
+  refDistance: 0.3,
+  rolloffFactor: 3
+};
+
+/** Underwater or heavily dampened environment. */
+const underwater: AudioAttenuationPreset = {
+  distanceModel: "exponential",
+  maxDistance: 20,
+  refDistance: 1,
+  rolloffFactor: 4
+};
+
+/** Linear falloff — useful for clearly defined audio zones. */
+const linearZone: AudioAttenuationPreset = {
+  distanceModel: "linear",
+  maxDistance: 30,
+  refDistance: 5,
+  rolloffFactor: 1
+};
+
+export const AUDIO_ATTENUATION_PRESETS = {
+  cathedral,
+  indoor,
+  intimate,
+  linearZone,
+  outdoor,
+  underwater
+} as const;

--- a/packages/runtime-audio/src/types.ts
+++ b/packages/runtime-audio/src/types.ts
@@ -1,0 +1,78 @@
+import type { Vec3 } from "@ggez/shared";
+
+/** Resolves a clip identifier to raw audio data the AudioManager can decode. */
+export type AudioClipResolver = (clipId: string) => Promise<ArrayBuffer> | ArrayBuffer;
+
+/** Web Audio API distance model for spatial attenuation. */
+export type AudioDistanceModel = "exponential" | "inverse" | "linear";
+
+/** Describes a single audio source managed by the AudioManager. */
+export type AudioSourceState = {
+  channel: AudioChannel;
+  clipId: string;
+  gainNode: GainNode;
+  id: string;
+  loop: boolean;
+  pannerNode?: PannerNode;
+  pitch: number;
+  source?: AudioBufferSourceNode;
+  spatial: boolean;
+  startedAt: number;
+  pausedAt: number;
+  paused: boolean;
+};
+
+/** Audio mixer channel name. */
+export type AudioChannel = "ambient" | "music" | "sfx" | "ui" | "voice";
+
+/** Options for playing a clip through the AudioManager. */
+export type AudioPlayOptions = {
+  channel?: AudioChannel;
+  clip: string;
+  distanceModel?: AudioDistanceModel;
+  id?: string;
+  loop?: boolean;
+  maxDistance?: number;
+  pitch?: number;
+  position?: Vec3;
+  refDistance?: number;
+  rolloffFactor?: number;
+  spatial?: boolean;
+  volume?: number;
+};
+
+/** Handle returned after playing a clip, allows controlling playback. */
+export type AudioSourceHandle = {
+  readonly id: string;
+  pause: () => void;
+  resume: () => void;
+  setPosition: (position: Vec3) => void;
+  setPitch: (rate: number) => void;
+  setVolume: (volume: number) => void;
+  stop: () => void;
+};
+
+/** Configuration for creating an AudioManager. */
+export type AudioManagerOptions = {
+  clipResolver: AudioClipResolver;
+  masterVolume?: number;
+};
+
+/** Descriptor extracted from a runtime scene for an audio emitter. */
+export type RuntimeAudioEmitterDescriptor = {
+  autoPlay: boolean;
+  clip: string;
+  distanceModel: AudioDistanceModel;
+  hookId: string;
+  loop: boolean;
+  maxDistance: number;
+  pitch: number;
+  position?: Vec3;
+  refDistance: number;
+  rolloffFactor: number;
+  spatial: boolean;
+  stopEvent?: string;
+  targetId: string;
+  triggerEvent?: string;
+  volume: number;
+};

--- a/packages/runtime-audio/tsconfig.json
+++ b/packages/runtime-audio/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "include": ["src/**/*"]
+}

--- a/packages/runtime-build/src/bundle.test.ts
+++ b/packages/runtime-build/src/bundle.test.ts
@@ -36,10 +36,12 @@ const runtimeScene: RuntimeScene = {
     player: {
       cameraMode: "fps",
       canCrouch: true,
+      canInteract: true,
       canJump: true,
       canRun: true,
       crouchHeight: 1.2,
       height: 1.8,
+      interactKey: "KeyE",
       jumpHeight: 1,
       movementSpeed: 4,
       runningSpeed: 6

--- a/packages/runtime-format/src/audio.ts
+++ b/packages/runtime-format/src/audio.ts
@@ -1,0 +1,53 @@
+import type { RuntimeAudioDescriptor, RuntimeScene } from "./types";
+
+/** Extract audio descriptors from entities and nodes that have `audio_emitter` hooks. */
+export function getRuntimeAudioDescriptors(
+  scene: Pick<RuntimeScene, "entities" | "nodes">
+): RuntimeAudioDescriptor[] {
+  const descriptors: RuntimeAudioDescriptor[] = [];
+
+  const processTarget = (targetId: string, hooks: RuntimeScene["entities"][number]["hooks"], transform?: { position: { x: number; y: number; z: number } }) => {
+    hooks?.forEach((hook) => {
+      if (hook.type !== "audio_emitter") {
+        return;
+      }
+
+      const clip = typeof hook.config.clip === "string" ? hook.config.clip : "";
+
+      if (!clip) {
+        return;
+      }
+
+      const position = transform?.position;
+
+      descriptors.push({
+        autoPlay: hook.config.autoPlay === true,
+        channel: typeof hook.config.channel === "string" ? hook.config.channel : "sfx",
+        clip,
+        distanceModel: typeof hook.config.distanceModel === "string" ? hook.config.distanceModel : "inverse",
+        hookId: hook.id,
+        loop: hook.config.loop === true,
+        maxDistance: typeof hook.config.maxDistance === "number" ? hook.config.maxDistance : 10000,
+        pitch: typeof hook.config.pitch === "number" ? hook.config.pitch : 1,
+        position: position ? { x: position.x, y: position.y, z: position.z } : undefined,
+        refDistance: typeof hook.config.refDistance === "number" ? hook.config.refDistance : 1,
+        rolloffFactor: typeof hook.config.rolloffFactor === "number" ? hook.config.rolloffFactor : 1,
+        spatial: hook.config.spatial === true,
+        stopEvent: typeof hook.config.stopEvent === "string" && hook.config.stopEvent.length > 0 ? hook.config.stopEvent : undefined,
+        targetId,
+        triggerEvent: typeof hook.config.triggerEvent === "string" && hook.config.triggerEvent.length > 0 ? hook.config.triggerEvent : undefined,
+        volume: typeof hook.config.volume === "number" ? hook.config.volume : 1
+      });
+    });
+  };
+
+  scene.entities.forEach((entity) => {
+    processTarget(entity.id, entity.hooks, entity.transform);
+  });
+
+  scene.nodes.forEach((node) => {
+    processTarget(node.id, node.hooks, node.transform);
+  });
+
+  return descriptors;
+}

--- a/packages/runtime-format/src/format.test.ts
+++ b/packages/runtime-format/src/format.test.ts
@@ -35,10 +35,12 @@ function createScene(version = CURRENT_RUNTIME_SCENE_VERSION): RuntimeScene {
       player: {
         cameraMode: "fps",
         canCrouch: true,
+        canInteract: true,
         canJump: true,
         canRun: true,
         crouchHeight: 1.2,
         height: 1.8,
+        interactKey: "KeyE",
         jumpHeight: 1,
         movementSpeed: 4,
         runningSpeed: 6

--- a/packages/runtime-format/src/index.ts
+++ b/packages/runtime-format/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
+export * from "./audio";
 export * from "./format";
 export * from "./physics";

--- a/packages/runtime-format/src/types.ts
+++ b/packages/runtime-format/src/types.ts
@@ -122,6 +122,25 @@ export type RuntimeWorldIndex = {
   version: number;
 };
 
+export type RuntimeAudioDescriptor = {
+  autoPlay: boolean;
+  channel: string;
+  clip: string;
+  distanceModel: string;
+  hookId: string;
+  loop: boolean;
+  maxDistance: number;
+  pitch: number;
+  position?: { x: number; y: number; z: number };
+  refDistance: number;
+  rolloffFactor: number;
+  spatial: boolean;
+  stopEvent?: string;
+  targetId: string;
+  triggerEvent?: string;
+  volume: number;
+};
+
 export type WebHammerExportMaterial = RuntimeMaterial;
 export type WebHammerExportPrimitive = RuntimePrimitive;
 export type WebHammerExportGeometry = RuntimeGeometry;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -190,7 +190,7 @@ export type GeometryNode = BrushNode | GroupNode | MeshNode | ModelNode | Primit
 
 export type Asset = {
   id: AssetID;
-  type: "model" | "material" | "prefab";
+  type: "audio" | "material" | "model" | "prefab";
   path: string;
   metadata: Record<string, MetadataValue>;
 };
@@ -276,10 +276,12 @@ export type ScenePathDefinition = {
 export type PlayerSettings = {
   cameraMode: PlayerCameraMode;
   canCrouch: boolean;
+  canInteract: boolean;
   canJump: boolean;
   canRun: boolean;
   crouchHeight: number;
   height: number;
+  interactKey: string;
   jumpHeight: number;
   movementSpeed: number;
   runningSpeed: number;

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -306,10 +306,12 @@ export function createDefaultSceneSettings(): SceneSettings {
     player: {
       cameraMode: "fps",
       canCrouch: true,
+      canInteract: true,
       canJump: true,
       canRun: true,
       crouchHeight: 1.2,
       height: 1.8,
+      interactKey: "KeyE",
       jumpHeight: 1.2,
       movementSpeed: 4.5,
       runningSpeed: 7.5

--- a/packages/three-runtime/src/loader.test.ts
+++ b/packages/three-runtime/src/loader.test.ts
@@ -65,10 +65,12 @@ describe("loadWebHammerEngineScene", () => {
         player: {
           cameraMode: "fps",
           canCrouch: true,
+          canInteract: true,
           canJump: true,
           canRun: true,
           crouchHeight: 1.2,
           height: 1.8,
+          interactKey: "KeyE",
           jumpHeight: 1,
           movementSpeed: 4,
           runningSpeed: 6
@@ -202,10 +204,12 @@ describe("loadWebHammerEngineScene", () => {
         player: {
           cameraMode: "fps",
           canCrouch: true,
+          canInteract: true,
           canJump: true,
           canRun: true,
           crouchHeight: 1.2,
           height: 1.8,
+          interactKey: "KeyE",
           jumpHeight: 1,
           movementSpeed: 4,
           runningSpeed: 6
@@ -331,10 +335,12 @@ describe("loadWebHammerEngineScene", () => {
         player: {
           cameraMode: "fps",
           canCrouch: true,
+          canInteract: true,
           canJump: true,
           canRun: true,
           crouchHeight: 1.2,
           height: 1.8,
+          interactKey: "KeyE",
           jumpHeight: 1,
           movementSpeed: 4,
           runningSpeed: 6
@@ -451,10 +457,12 @@ describe("loadWebHammerEngineScene", () => {
         player: {
           cameraMode: "fps",
           canCrouch: true,
+          canInteract: true,
           canJump: true,
           canRun: true,
           crouchHeight: 1.2,
           height: 1.8,
+          interactKey: "KeyE",
           jumpHeight: 1,
           movementSpeed: 4,
           runningSpeed: 6
@@ -557,10 +565,12 @@ describe("loadWebHammerEngineScene", () => {
         player: {
           cameraMode: "fps",
           canCrouch: true,
+          canInteract: true,
           canJump: true,
           canRun: true,
           crouchHeight: 1.2,
           height: 1.8,
+          interactKey: "KeyE",
           jumpHeight: 1,
           movementSpeed: 4,
           runningSpeed: 6

--- a/packages/three-runtime/src/loader.ts
+++ b/packages/three-runtime/src/loader.ts
@@ -37,9 +37,11 @@ import { HDRLoader } from "three/examples/jsm/loaders/HDRLoader.js";
 import { MTLLoader } from "three/examples/jsm/loaders/MTLLoader.js";
 import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js";
 import {
+  getRuntimeAudioDescriptors,
   isRuntimeBundle,
   isRuntimeScene,
   parseRuntimeScene,
+  type RuntimeAudioDescriptor,
   type RuntimeScene
 } from "@ggez/runtime-format";
 import {
@@ -95,6 +97,7 @@ export type WebHammerSceneLodOptions = {
 };
 
 export type ThreeRuntimeSceneInstance = {
+  audioDescriptors: RuntimeAudioDescriptor[];
   dispose: () => void;
   entities: WebHammerEngineScene["entities"];
   lights: Object3D[];
@@ -254,6 +257,7 @@ export async function createThreeRuntimeSceneInstance(
   }
 
   return {
+    audioDescriptors: getRuntimeAudioDescriptors(engineScene),
     dispose() {
       disposeThreeRuntimeSceneInstance(root);
     },

--- a/packages/workers/src/export-tasks.test.ts
+++ b/packages/workers/src/export-tasks.test.ts
@@ -8,10 +8,12 @@ const settings: SceneSettings = {
   player: {
     cameraMode: "fps",
     canCrouch: true,
+    canInteract: true,
     canJump: true,
     canRun: true,
     crouchHeight: 1.2,
     height: 1.8,
+    interactKey: "KeyE",
     jumpHeight: 1,
     movementSpeed: 4,
     runningSpeed: 6


### PR DESCRIPTION
## Summary

- **Node-based logic viewer** — Unreal Blueprint-style visual graph editor for gameplay hook wiring. Card nodes with color-coded input/output ports per hook, smooth-step edges with event labels, auto-clustered connected components, dagre auto-layout, drag-to-connect creates real hook mutations (binds fromEntity/target or auto-generates bridge sequences)
- **DestructibleSystem** — handles damage.killed / destroy.requested with disable, spawn_prefab, swap_mesh, explode modes
- **VfxEmitterSystem** — dynamic event→vfxId subscriptions via eventMap config, vfx.play/stop/stop_all
- **Interact key** — `canInteract` + `interactKey` in PlayerSettings, editor UI with key capture widget, both playgrounds emit interact.requested on keydown

## Logic Viewer details

| Component | Role |
|-----------|------|
| `LogicNode` | Card-style node with per-hook sections, input/output port rows |
| `LogicEdge` | Glow + stroke path, event label, color-coded by category |
| `LogicClusterNode` | Auto-grouped connected component with dashed border |
| `logic-graph.ts` | Derives directed graph from scene, indexes static + dynamic ports, BFS clustering |
| `logic-connect.ts` | Drag-to-connect: binds existing hooks or creates bridge sequence |
| `logic-layout.ts` | Dagre LR auto-layout |
| `logic-theme.ts` | 13 category color palettes (Interaction, Trigger, State, Motion, Combat, Feedback, Logic…) |

## Test plan

- [x] `cd apps/editor && bun run typecheck` — 0 errors
- [x] `cd apps/three-vanilla-playground && bun run build` — success
- [x] `cd apps/three-runtime-playground && bun run build` — success
- [x] Editor Player tab → Interaction section visible with toggle + key field
- [x] Logic viewer renders hook graph with color-coded nodes and edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)